### PR TITLE
Add a Create Edit Questions Button for Surveys that are not Published

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/MySurveys.razor
+++ b/JwtIdentity.Client/Pages/Survey/MySurveys.razor
@@ -14,12 +14,12 @@
             <Template>
                 <MudStack Spacing="2" Row="true" Class="py-1" >
                 @{
-                        var guid = (context as SurveyViewModel).Guid;
+                    var guid = (context as SurveyViewModel).Guid;
 
-                        <MudButton Class=@($"copy_button {ShareButtonDisabled((context as SurveyViewModel).Published)}") Variant="Variant.Filled" Color="Color.Primary" OnClick="@(async () => await CopySurveyLinkAsync(guid))" title="@(GetTitleText((context as SurveyViewModel).Published))">Copy Survey Link</MudButton>
-                    }
+                        <MudButton Class=@($"mysurvey_buttons copy_button {ShareButtonDisabled((context as SurveyViewModel).Published, true)}") Variant="Variant.Filled" Color="Color.Primary" OnClick="@(async () => await CopySurveyLinkAsync(guid))" title="@(GetTitleText((context as SurveyViewModel).Published))">Copy Survey Link</MudButton>
+                }
 
-                    <div class=@($"fb-share-button d-flex {ShareButtonDisabled((context as SurveyViewModel).Published)}")
+                    <div class=@($"fb-share-button d-flex {ShareButtonDisabled((context as SurveyViewModel).Published, true)}")
                          data-href=@($"https://www.davidtest.xyz/survey/{guid}")
                          data-layout="button_count"
                          data-size="small"
@@ -30,7 +30,9 @@
                             <path class="svg-icon-path" d="M9.1,0.1V2H8C7.6,2,7.3,2.1,7.1,2.3C7,2.4,6.9,2.7,6.9,3v1.4H9L8.8,6.5H6.9V12H4.7V6.5H2.9V4.4h1.8V2.8 c0-0.9,0.3-1.6,0.7-2.1C6,0.2,6.6,0,7.5,0C8.2,0,8.7,0,9.1,0.1z"></path>
                         </svg>
                     </div>
-               </MudStack>
+
+                    <MudButton Class=@($"mysurvey_buttons addEditQuestions_button {ShareButtonDisabled((context as SurveyViewModel).Published, false)}") Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => AddEditQuestions((context as SurveyViewModel).Guid, (context as SurveyViewModel).Published))">Add/Edit Questions</MudButton>
+                </MudStack>
             </Template>
         </GridColumn>
     </GridColumns>

--- a/JwtIdentity.Client/Pages/Survey/MySurveys.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/MySurveys.razor.cs
@@ -18,7 +18,7 @@ namespace JwtIdentity.Client.Pages.Survey
 
         protected static string GetTitleText(bool published) => published ? "Copy Survey Link" : "Survey not published";
 
-        protected static string ShareButtonDisabled(bool published) => published ? "" : "disabled";
+        protected static string ShareButtonDisabled(bool published, bool disabledCondition) => published == disabledCondition ? "" : "disabled";
 
         protected override async Task OnInitializedAsync()
         {
@@ -67,6 +67,17 @@ namespace JwtIdentity.Client.Pages.Survey
 
             // Open the URL in a new tab
             await JSRuntime.InvokeVoidAsync("open", url, "_blank");
+        }
+
+        protected void AddEditQuestions(string guid, bool published)
+        {
+            if (published)
+            {
+                _ = Snackbar.Add("Survey published. You cannot edit survey questions once it has been published", Severity.Error);
+                return;
+            }
+
+            NavigationManager.NavigateTo($"/survey/createquestions/{guid}");
         }
     }
 }

--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -130,7 +130,7 @@ h1:focus {
         padding: 0 3px
     }
 
-.copy_button {
+.mysurvey_buttons {
     margin-top: auto;
     margin-bottom: auto;
     height: 28px;


### PR DESCRIPTION
- Modified button styles in `MySurveys.razor` to use `mysurvey_buttons`.
- Enhanced `ShareButtonDisabled` method to accept an additional parameter for better control over button states.
- Added `Add/Edit Questions` button with navigation logic for unpublished surveys.
- Updated CSS in `app.css` to reflect new button class usage.