### PR TITLE
Update Syncfusion packages and enhance chart export feature

### DIFF
--- a/JwtIdentity.Client/JwtIdentity.Client.csproj
+++ b/JwtIdentity.Client/JwtIdentity.Client.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.1" />
     <PackageReference Include="MudBlazor" Version="8.2.0" />
-    <PackageReference Include="Syncfusion.Blazor" Version="28.2.7" />
-    <PackageReference Include="Syncfusion.Blazor.Themes" Version="28.2.7" />
+    <PackageReference Include="Syncfusion.Blazor" Version="28.2.12" />
+    <PackageReference Include="Syncfusion.Blazor.Themes" Version="28.2.12" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.1" />
   </ItemGroup>
 

--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
@@ -1,4 +1,5 @@
 ﻿@page "/survey/responses/{SurveyId}"
+@using ExportType = Syncfusion.Blazor.Charts.ExportType
 @inherits BarChartModel
 
 @if (SurveyData != null && SurveyChartData != null && SelectedQuestion != null)
@@ -9,8 +10,19 @@
             <MudSelectItem T="QuestionViewModel" Value="@question">@question.Text</MudSelectItem>
         }
     </MudSelect>
-    
-    <SfChart Title="@SelectedQuestion.Text" Theme="@CurrentTheme">
+
+    <MudStack Row="true" Class="mb-1">
+        <MudSelect T="ExportType" Label="Select Export Type" @bind-Value="SelectedExportType" Variant="Variant.Filled" Class="mb-1">
+            @foreach (var exportType in Enum.GetValues(typeof(ExportType)).Cast<ExportType>())
+            {
+                <MudSelectItem T="ExportType" Value="@exportType">@exportType.ToString()</MudSelectItem>
+            }
+        </MudSelect>
+        
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="my-1" OnClick="ExportChart" Size="MudBlazor.Size.Small">Export Chart</MudButton>
+    </MudStack>    
+
+    <SfChart @ref="chartObj" Title="@SelectedQuestion.Text" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
         <ChartTooltipSettings Enable="true" />
         <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category" />
         <ChartPrimaryYAxis Interval="1"  />

--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
@@ -1,4 +1,6 @@
-﻿namespace JwtIdentity.Client.Pages.Survey.Results
+﻿using Syncfusion.Blazor.Charts;
+
+namespace JwtIdentity.Client.Pages.Survey.Results
 {
     public class BarChartModel : BlazorBase
     {
@@ -8,6 +10,8 @@
         [Parameter]
         public string SurveyId { get; set; }
 
+        protected SfChart chartObj;
+
         protected List<SurveyDataViewModel> SurveyData { get; set; } = new();
 
         protected List<ChartData> SurveyChartData { get; set; } = new List<ChartData>();
@@ -15,6 +19,12 @@
         protected QuestionViewModel SelectedQuestion { get; set; }
 
         protected Theme CurrentTheme => Theme == "dark" ? Syncfusion.Blazor.Theme.Tailwind3Dark : Syncfusion.Blazor.Theme.Material3;
+
+        protected string ChartWidth { get; set; } = "100%";
+
+        protected string ChartHeight { get; set; } = "100%";
+
+        protected ExportType SelectedExportType { get; set; } = ExportType.PDF;
 
         protected override async Task OnInitializedAsync()
         {
@@ -37,6 +47,17 @@
             SelectedQuestion = question;
 
             SurveyChartData = SurveyData.Where(x => x.Question == question).Select(x => x.SurveyData).FirstOrDefault();
+        }
+
+        protected async Task ExportChart()
+        {
+            ChartWidth = "1000";
+            ChartHeight = "650";
+
+            await chartObj.ExportAsync(SelectedExportType, $"Chart.{SelectedExportType}", Syncfusion.PdfExport.PdfPageOrientation.Landscape, true);
+
+            ChartWidth = "100%";
+            ChartHeight = "100%";
         }
     }
 }

--- a/JwtIdentity.Client/Pages/Survey/Results/Filter.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Results/Filter.razor.cs
@@ -7,7 +7,7 @@ namespace JwtIdentity.Client.Pages.Survey.Results
         [Parameter]
         public string SurveyId { get; set; }
 
-        protected SfGrid<object> Grid;
+        protected SfGrid<object> Grid { get; set; }
 
         protected SurveyViewModel Survey { get; set; }
 
@@ -57,10 +57,7 @@ namespace JwtIdentity.Client.Pages.Survey.Results
         }
 
         // Suppose we have a method to build "row objects" for each response
-        public IEnumerable<object> BuildSurveyRows(
-            Type dynamicSurveyType,
-            Dictionary<int, string> propertyMap,
-            List<AnswerViewModel> answersForAllResponses)
+        private IEnumerable<object> BuildSurveyRows(Type dynamicSurveyType, Dictionary<int, string> propertyMap, List<AnswerViewModel> answersForAllResponses)
         {
             // Group answers by some "ResponseId" or "IpAddress" etc.
             var grouped = answersForAllResponses
@@ -81,7 +78,7 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                         // This means "Q_29" or "Q_42", etc.
 
                         // We'll figure out how to convert 'ans' to the correct property value
-                        object? propValue = ConvertAnswerValue(ans);
+                        object propValue = ConvertAnswerValue(ans);
 
                         // Finally set the property on rowInstance
                         dynamicSurveyType.GetProperty(propName)?.SetValue(rowInstance, propValue);
@@ -94,7 +91,7 @@ namespace JwtIdentity.Client.Pages.Survey.Results
             return rowObjects;
         }
 
-        private object? ConvertAnswerValue(AnswerViewModel ans)
+        private object ConvertAnswerValue(AnswerViewModel ans)
         {
             // You might switch on ans.AnswerType or check the derived class
             // to return the correct .NET type (string, bool?, int?, etc.)
@@ -135,11 +132,13 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                 // For question ID 29, property name is "Q_29"
                 string propertyName = _propertyMap[q.Id];
 
+#pragma warning disable BL0005 // Component parameter should not be set outside of its component.
                 var gridColumn = new GridColumn
                 {
                     Field = propertyName,
                     HeaderText = q.Text
                 };
+
 
                 // Decide the column type based on the question type
                 switch (q.QuestionType)
@@ -152,11 +151,8 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                     case QuestionType.TrueFalse:
                         gridColumn.Type = ColumnType.Boolean;
                         break;
-
-                        // If you had a numeric question type,
-                        // you might do: gridColumn.Type = ColumnType.Number;
                 }
-
+#pragma warning restore BL0005 // Component parameter should not be set outside of its component.
                 Grid.Columns.Add(gridColumn);
             }
         }


### PR DESCRIPTION
- Updated `Syncfusion.Blazor` and `Syncfusion.Blazor.Themes` versions to `28.2.12`.
- Added export functionality in `BarChart.razor` with a new `MudSelect` for export type selection and a `MudButton` for triggering the export.
- Modified `BarChart.razor.cs` to include properties for chart dimensions and export type, and introduced the `ExportChart` method.
- Refactored `Filter.razor.cs` to change `Grid` to a property, updated method visibility, and adjusted return types for better clarity.
- Cleaned up code by removing unnecessary comments and refining grid column handling based on question types.