### PR TITLE
Add chart type selection and export functionality

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
@@ -12,24 +12,45 @@
     </MudSelect>
 
     <MudStack Row="true" Class="mb-1">
+        <MudSelect T="string" Label="Select Chart Type" @bind-Value="SelectedChartType" Variant="Variant.Filled" Class="mb-1">
+            <MudSelectItem T="string" Value="@("Bar")" >Bar</MudSelectItem>
+            <MudSelectItem T="string" Value="@("Pie")">Pie</MudSelectItem>
+        </MudSelect>
+
         <MudSelect T="ExportType" Label="Select Export Type" @bind-Value="SelectedExportType" Variant="Variant.Filled" Class="mb-1">
             @foreach (var exportType in Enum.GetValues(typeof(ExportType)).Cast<ExportType>())
             {
                 <MudSelectItem T="ExportType" Value="@exportType">@exportType.ToString()</MudSelectItem>
             }
         </MudSelect>
-        
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="my-1" OnClick="ExportChart" Size="MudBlazor.Size.Small">Export Chart</MudButton>
-    </MudStack>    
 
-    <SfChart @ref="chartObj" Title="@SelectedQuestion.Text" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
-        <ChartTooltipSettings Enable="true" />
-        <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category" />
-        <ChartPrimaryYAxis Interval="1"  />
-        <ChartSeriesCollection>
-            <ChartSeries DataSource="@SurveyChartData" XName="X" YName="Y" Type="ChartSeriesType.Column" Fill="rgba(61, 44, 191, 1)" />          
-        </ChartSeriesCollection>
-    </SfChart>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="my-1" OnClick="ExportChart" Size="MudBlazor.Size.Small">Export Chart</MudButton>
+    </MudStack>
+
+    @switch (SelectedChartType)
+    {
+        case "Bar":
+            <SfChart @ref="chartObj" Title="@SelectedQuestion.Text" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
+                <ChartTooltipSettings Enable="true" />
+                <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category" />
+                <ChartPrimaryYAxis Interval="1" />
+                <ChartSeriesCollection>
+                    <ChartSeries DataSource="@SurveyChartData" XName="X" YName="Y" Type="ChartSeriesType.Column" Fill="rgba(61, 44, 191, 1)" />
+                </ChartSeriesCollection>
+            </SfChart>
+            break;
+
+        case "Pie":
+            <SfAccumulationChart @ref="pieChartObj" Title="@SelectedQuestion.Text" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
+                <AccumulationChartTooltipSettings Enable="true" />
+                <AccumulationChartSeriesCollection>
+                    <AccumulationChartSeries DataSource="@PieChartData" XName="X" YName="Y" Radius="70%">
+                        <AccumulationDataLabelSettings Visible="true" Position="AccumulationLabelPosition.Outside" Format="{value}%" />
+                    </AccumulationChartSeries>
+                </AccumulationChartSeriesCollection>
+            </SfAccumulationChart>
+            break;
+    }
 }
 
 

--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
@@ -10,11 +10,15 @@ namespace JwtIdentity.Client.Pages.Survey.Results
         [Parameter]
         public string SurveyId { get; set; }
 
-        protected SfChart chartObj;
+        protected SfChart chartObj { get; set; }
+
+        protected SfAccumulationChart pieChartObj { get; set; }
 
         protected List<SurveyDataViewModel> SurveyData { get; set; } = new();
 
         protected List<ChartData> SurveyChartData { get; set; } = new List<ChartData>();
+
+        protected List<ChartData> PieChartData { get; set; } = new List<ChartData>();
 
         protected QuestionViewModel SelectedQuestion { get; set; }
 
@@ -26,9 +30,13 @@ namespace JwtIdentity.Client.Pages.Survey.Results
 
         protected ExportType SelectedExportType { get; set; } = ExportType.PDF;
 
+        protected string SelectedChartType { get; set; } = "Bar";
+
         protected override async Task OnInitializedAsync()
         {
             await LoadData();
+
+            StateHasChanged();
         }
 
         private async Task LoadData()
@@ -47,14 +55,35 @@ namespace JwtIdentity.Client.Pages.Survey.Results
             SelectedQuestion = question;
 
             SurveyChartData = SurveyData.Where(x => x.Question == question).Select(x => x.SurveyData).FirstOrDefault();
+
+            PieChartData = new List<ChartData>();
+
+            foreach (ChartData data in SurveyChartData)
+            {
+
+                PieChartData.Add(new ChartData() { X = data.X, Y = data.Y / SurveyChartData.Sum(d => d.Y) * 100 });
+            }
         }
 
         protected async Task ExportChart()
         {
-            ChartWidth = "1000";
-            ChartHeight = "650";
+            switch (SelectedChartType)
+            {
+                case "Bar":
+                    ChartWidth = "1000";
+                    ChartHeight = "650";
+                    await chartObj.ExportAsync(SelectedExportType, $"Chart.{SelectedExportType}", Syncfusion.PdfExport.PdfPageOrientation.Landscape, true);
+                    break;
 
-            await chartObj.ExportAsync(SelectedExportType, $"Chart.{SelectedExportType}", Syncfusion.PdfExport.PdfPageOrientation.Landscape, true);
+                case "Pie":
+                    ChartWidth = "1000";
+                    ChartHeight = "700";
+
+                    await Task.Delay(100);
+
+                    await pieChartObj.ExportAsync(SelectedExportType, $"Chart.{SelectedExportType}", Syncfusion.PdfExport.PdfPageOrientation.Landscape, true);
+                    break;
+            }
 
             ChartWidth = "100%";
             ChartHeight = "100%";


### PR DESCRIPTION
Introduces a new `MudSelect` component in `BarChart.razor` to allow users to choose between "Bar" and "Pie" charts. Updates rendering logic to switch between `SfChart` and `SfAccumulationChart` based on the selected type. Adds `SelectedChartType` property and modifies the `ExportChart` method to handle exports for both chart types. In `BarChart.razor.cs`, introduces `PieChartData` for pie chart data and updates `HandleSelectQuestion` to populate this list.