### PR TITLE
Add "Select All That Apply" question type

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/CreateQuestions.razor
+++ b/JwtIdentity.Client/Pages/Survey/CreateQuestions.razor
@@ -32,13 +32,14 @@
                             </MudSelect>
 
                             <MudText Typo="Typo.h6" Class="mt-5">Create a @StringHelper.PascalCaseToWords(SelectedQuestionType) Question</MudText>
-                            <MudTextField id="Text" Label="Question Text" @bind-Value="QuestionText" Variant="Variant.Filled" Lines="1" MaxLines="5" AutoGrow="true" Immediate="true" Counter="50" MaxLength="50" />
+                            <MudTextField id="Text" Label="Question Text" @bind-Value="QuestionText" Variant="Variant.Filled" Lines="1" MaxLines="5" AutoGrow="true" Immediate="true" Counter="500" MaxLength="500" />
                         </MudStack>
 
-                        <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" OnClick="AddQuestionToSurvey" Disabled="@AddQuestionToSurveyDisabled">Submit Question</MudButton>
+                        <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" OnClick="AddQuestionToSurvey" Disabled="@AddQuestionToSurveyDisabled">Save Question</MudButton>
                     </MudPaper>
 
-                    @if (SelectedQuestionType.Replace(" ", "") == Enum.GetName(QuestionType.MultipleChoice))
+                    @if (SelectedQuestionType.Replace(" ", "") == Enum.GetName(QuestionType.MultipleChoice) || 
+                        SelectedQuestionType.Replace(" ", "") == Enum.GetName(QuestionType.SelectAllThatApply))
                     {
                         <MudPaper>
                             <MudText Typo="Typo.h6" Class="mb-1">Add the Question Choices</MudText>

--- a/JwtIdentity.Client/Pages/Survey/Results/Filter.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Results/Filter.razor.cs
@@ -104,6 +104,9 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                 case AnswerType.TrueFalse:
                     return (ans as TrueFalseAnswerViewModel)?.Value;
 
+                case AnswerType.Rating1To10:
+                    return (ans as Rating1To10AnswerViewModel)?.SelectedOptionId;
+
                 case AnswerType.MultipleChoice:
                 case AnswerType.SingleChoice:
 
@@ -117,6 +120,32 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                             .FirstOrDefault(o => o.Id == ans.SelectedOptionValue);
 
                         return option?.OptionText;
+                    }
+                    return null;
+
+                case AnswerType.SelectAllThatApply:
+                    var selectAllQuestion = Survey.Questions
+                        .OfType<SelectAllThatApplyQuestionViewModel>()
+                        .FirstOrDefault(q => q.Id == ans.QuestionId);
+
+                    if (selectAllQuestion != null && ans is SelectAllThatApplyAnswerViewModel selectAllAns)
+                    {
+                        if (string.IsNullOrEmpty(selectAllAns.SelectedOptionIds))
+                            return null;
+
+                        // Get the IDs of the selected options
+                        var selectedIds = selectAllAns.SelectedOptionIds
+                            .Split(',')
+                            .Select(int.Parse)
+                            .ToHashSet();
+
+                        // Get the text of the selected options
+                        var selectedOptions = selectAllQuestion.Options
+                            .Where(o => selectedIds.Contains(o.Id))
+                            .Select(o => o.OptionText);
+
+                        // Join them with commas for display
+                        return string.Join(", ", selectedOptions);
                     }
                     return null;
 
@@ -145,11 +174,16 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                 {
                     case QuestionType.Text:
                     case QuestionType.MultipleChoice:
+                    case QuestionType.SelectAllThatApply:
                         gridColumn.Type = ColumnType.String;
                         break;
 
                     case QuestionType.TrueFalse:
                         gridColumn.Type = ColumnType.Boolean;
+                        break;
+
+                    case QuestionType.Rating1To10:
+                        gridColumn.Type = ColumnType.Integer;
                         break;
                 }
 #pragma warning restore BL0005 // Component parameter should not be set outside of its component.

--- a/JwtIdentity.Client/Pages/Survey/Survey.razor
+++ b/JwtIdentity.Client/Pages/Survey/Survey.razor
@@ -72,6 +72,31 @@ else
                         </MudStack>
                     </MudRadioGroup>
                 }
+                else if (question.QuestionType == QuestionType.SelectAllThatApply)
+                {
+                    var saQuestion = question as SelectAllThatApplyQuestionViewModel;
+                    SelectAllThatApplyAnswerViewModel saAnswer = saQuestion.Answers.FirstOrDefault() as SelectAllThatApplyAnswerViewModel;
+                    
+                    <MudStack Spacing="0">
+                        @for (int i = 0; i < saQuestion.Options.Count; i++)
+                        {
+                            var option = saQuestion.Options[i];
+                            var index = i; // Capture the index for the closure
+                            
+                            // Ensure the SelectedOptions list has enough elements
+                            while (saAnswer.SelectedOptions.Count <= index)
+                            {
+                                saAnswer.SelectedOptions.Add(false);
+                            }
+                            
+                            <MudCheckBox @key="option" 
+                                         T="bool"
+                                         Label="@option.OptionText" 
+                                         Value="@saAnswer.SelectedOptions[index]" 
+                                         ValueChanged="@((bool v) => HandleSelectAllThatApplyOption(saAnswer, index, v, option.Id))" />
+                        }
+                    </MudStack>
+                }
             }
         }
 

--- a/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
@@ -94,6 +94,91 @@ namespace JwtIdentity.Client.Pages.Survey
             }
         }
 
+        /*    private async Task LoadData()
+            {
+                // get the survey based on the SurveyId
+                Survey = await ApiService.GetAsync<SurveyViewModel>($"{ApiEndpoints.Answer}/getanswersforsurveyforloggedinuser/{SurveyId}?Preview={Preview}");
+
+                if (Survey != null && Survey.Id > 0)
+                {
+                    foreach (var question in Survey.Questions)
+                    {
+                        if (question.Answers.Count == 0)
+                        {
+                            if (question.QuestionType == QuestionType.MultipleChoice)
+                            {
+                                MultipleChoiceAnswerViewModel answer = new()
+                                {
+                                    AnswerType = AnswerType.MultipleChoice,
+                                    QuestionId = question.Id
+                                };
+
+                                question.Answers.Add(answer);
+                            }
+
+                            else if (question.QuestionType == QuestionType.Text)
+                            {
+                                TextAnswerViewModel answer = new()
+                                {
+                                    AnswerType = AnswerType.Text,
+                                    QuestionId = question.Id
+                                };
+
+                                question.Answers.Add(answer);
+                            }
+
+                            else if (question.QuestionType == QuestionType.TrueFalse)
+                            {
+                                TrueFalseAnswerViewModel answer = new()
+                                {
+                                    AnswerType = AnswerType.TrueFalse,
+                                    QuestionId = question.Id,
+                                    Value = null
+                                };
+
+                                question.Answers.Add(answer);
+                            }
+                            else if (question.QuestionType == QuestionType.Rating1To10)
+                            {
+                                Rating1To10AnswerViewModel answer = new()
+                                {
+                                    AnswerType = AnswerType.Rating1To10,
+                                    QuestionId = question.Id
+                                };
+
+                                question.Answers.Add(answer);
+                            }
+                            else if (question.QuestionType == QuestionType.SelectAllThatApply)
+                            {
+                                SelectAllThatApplyAnswerViewModel answer = new()
+                                {
+                                    AnswerType = AnswerType.SelectAllThatApply,
+                                    QuestionId = question.Id,
+                                    Options = ((SelectAllThatApplyQuestionViewModel)question).Options,
+                                    SelectedOptions = new List<bool>()
+                                };
+
+                                // Initialize the SelectedOptions list with false values for each option
+                                for (int i = 0; i < ((SelectAllThatApplyQuestionViewModel)question).Options.Count; i++)
+                                {
+                                    answer.SelectedOptions.Add(false);
+                                }
+
+                                question.Answers.Add(answer);
+                            }
+                        }
+                        else
+                        { // this user or ip address has answered this before
+
+                        }
+                    }
+                }
+                else
+                {
+                    NavigationManager.NavigateTo("/");
+                }
+            }*/
+
         private async Task LoadData()
         {
             // get the survey based on the SurveyId
@@ -103,9 +188,10 @@ namespace JwtIdentity.Client.Pages.Survey
             {
                 foreach (var question in Survey.Questions)
                 {
-                    if (question.Answers.Count == 0)
+
+                    if (question.QuestionType == QuestionType.MultipleChoice)
                     {
-                        if (question.QuestionType == QuestionType.MultipleChoice)
+                        if (question.Answers.Count == 0)
                         {
                             MultipleChoiceAnswerViewModel answer = new()
                             {
@@ -115,8 +201,10 @@ namespace JwtIdentity.Client.Pages.Survey
 
                             question.Answers.Add(answer);
                         }
-
-                        else if (question.QuestionType == QuestionType.Text)
+                    }
+                    else if (question.QuestionType == QuestionType.Text)
+                    {
+                        if (question.Answers.Count == 0)
                         {
                             TextAnswerViewModel answer = new()
                             {
@@ -126,8 +214,10 @@ namespace JwtIdentity.Client.Pages.Survey
 
                             question.Answers.Add(answer);
                         }
-
-                        else if (question.QuestionType == QuestionType.TrueFalse)
+                    }
+                    else if (question.QuestionType == QuestionType.TrueFalse)
+                    {
+                        if (question.Answers.Count == 0)
                         {
                             TrueFalseAnswerViewModel answer = new()
                             {
@@ -138,7 +228,10 @@ namespace JwtIdentity.Client.Pages.Survey
 
                             question.Answers.Add(answer);
                         }
-                        else if (question.QuestionType == QuestionType.Rating1To10)
+                    }
+                    else if (question.QuestionType == QuestionType.Rating1To10)
+                    {
+                        if (question.Answers.Count == 0)
                         {
                             Rating1To10AnswerViewModel answer = new()
                             {
@@ -149,9 +242,50 @@ namespace JwtIdentity.Client.Pages.Survey
                             question.Answers.Add(answer);
                         }
                     }
-                    else
-                    { // this user or ip address has answered this before
+                    else if (question.QuestionType == QuestionType.SelectAllThatApply)
+                    {
+                        var saQuestion = question as SelectAllThatApplyQuestionViewModel;
 
+                        if (question.Answers.Count == 0)
+                        {
+                            SelectAllThatApplyAnswerViewModel answer = new()
+                            {
+                                AnswerType = AnswerType.SelectAllThatApply,
+                                QuestionId = question.Id,
+                                Options = ((SelectAllThatApplyQuestionViewModel)question).Options,
+                                SelectedOptions = new List<bool>()
+                            };
+
+                            // Initialize the SelectedOptions list with false values for each option
+                            for (int i = 0; i < ((SelectAllThatApplyQuestionViewModel)question).Options.Count; i++)
+                            {
+                                answer.SelectedOptions.Add(false);
+                            }
+
+                            question.Answers.Add(answer);
+                        }
+                        else
+                        {
+                            // Populate the SelectedOptions list with values from the database
+                            if (question.QuestionType == QuestionType.SelectAllThatApply)
+                            {
+                                var answer = question.Answers.FirstOrDefault() as SelectAllThatApplyAnswerViewModel;
+
+                                if (answer != null)
+                                {
+                                    while (answer.SelectedOptions.Count < saQuestion.Options.Count)
+                                    {
+                                        answer.SelectedOptions.Add(false);
+                                    }
+
+                                    var selectedOptionIds = answer.SelectedOptionIds?.Split(',').Select(int.Parse).ToList() ?? new List<int>();
+                                    for (int i = 0; i < saQuestion.Options.Count; i++)
+                                    {
+                                        answer.SelectedOptions[i] = selectedOptionIds.Contains(saQuestion.Options[i].Id);
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -342,11 +476,66 @@ namespace JwtIdentity.Client.Pages.Survey
                             return false;
                         }
                         break;
+                    case QuestionType.SelectAllThatApply:
+                        // Check if at least one option is selected for SelectAllThatApply questions
+                        var selectAllAnswer = (SelectAllThatApplyAnswerViewModel)question.Answers[0];
+                        if (string.IsNullOrEmpty(selectAllAnswer.SelectedOptionIds) ||
+                            !selectAllAnswer.SelectedOptions.Any(opt => opt))
+                        {
+                            return false;
+                        }
+                        break;
                     default:
                         break;
                 }
             }
             return true;
+        }
+
+        protected async Task HandleSelectAllThatApplyOption(SelectAllThatApplyAnswerViewModel answer, int index, bool isChecked, int optionId)
+        {
+            // Update the selected option in the SelectedOptions list
+            answer.SelectedOptions[index] = isChecked;
+
+            // Update the SelectedOptionIds string (comma-separated values)
+            var selectedIds = new List<int>();
+            for (int i = 0; i < answer.SelectedOptions.Count; i++)
+            {
+                if (answer.SelectedOptions[i])
+                {
+                    var option = ((SelectAllThatApplyQuestionViewModel)Survey.Questions.First(q => q.Id == answer.QuestionId)).Options[i];
+                    selectedIds.Add(option.Id);
+                }
+            }
+
+            answer.SelectedOptionIds = string.Join(",", selectedIds);
+
+            // Save the answer
+            if (!Preview)
+            {
+                var response = await ApiService.PostAsync(ApiEndpoints.Answer, answer);
+                if (response != null)
+                {
+                    // Update the answer in the Survey.Questions
+                    //foreach (var question in Survey.Questions)
+                    //{
+                    //    if (question.Id == answer.QuestionId)
+                    //    {
+                    //        for (int i = 0; i < question.Answers.Count; i++)
+                    //        {
+                    //            if (question.Answers[i].Id == answer.Id)
+                    //            {
+                    //                question.Answers[i] = response;
+                    //            }
+                    //        }
+                    //    }
+                    //}
+
+                    await LoadData(); // Reload the data to reflect the changes
+                }
+            }
+
+            StateHasChanged();
         }
     }
 }

--- a/JwtIdentity.Common/Helpers/AnswerType.cs
+++ b/JwtIdentity.Common/Helpers/AnswerType.cs
@@ -7,6 +7,7 @@
         SingleChoice = 3,
         MultipleChoice = 4,
         Rating1To10 = 5,
+        SelectAllThatApply = 6,
         // etc.
     }
 }

--- a/JwtIdentity.Common/Helpers/DynamicSurveyTypeBuilder.cs
+++ b/JwtIdentity.Common/Helpers/DynamicSurveyTypeBuilder.cs
@@ -67,6 +67,8 @@ namespace JwtIdentity.Common.Helpers
                 QuestionType.Text => typeof(string),
                 QuestionType.TrueFalse => typeof(bool?),
                 QuestionType.MultipleChoice => typeof(string),
+                QuestionType.Rating1To10 => typeof(int?), // or byte? if you prefer
+                QuestionType.SelectAllThatApply => typeof(string), // Store as comma-separated values string
                 _ => typeof(string) // fallback
             };
         }

--- a/JwtIdentity.Common/Helpers/QuestionType.cs
+++ b/JwtIdentity.Common/Helpers/QuestionType.cs
@@ -6,5 +6,6 @@
         TrueFalse = 2,
         MultipleChoice = 3,
         Rating1To10 = 4,
+        SelectAllThatApply = 5,
     }
 }

--- a/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
@@ -31,6 +31,7 @@ namespace JwtIdentity.Common.ViewModels
                 MultipleChoiceAnswerViewModel m => m.SelectedOptionId,
                 SingleChoiceAnswerViewModel s => s.SelectedOptionId,
                 Rating1To10AnswerViewModel r => r.SelectedOptionId,
+                SelectAllThatApplyAnswerViewModel => null, // Multiple selections, no single value
                 _ => null
             };
     }
@@ -62,6 +63,13 @@ namespace JwtIdentity.Common.ViewModels
         public int SelectedOptionId { get; set; }
     }
 
+    public class SelectAllThatApplyAnswerViewModel : AnswerViewModel
+    {
+        public string SelectedOptionIds { get; set; }
+        public List<bool> SelectedOptions { get; set; } = new List<bool>();
+        public List<ChoiceOptionViewModel> Options { get; set; }
+    }
+
     public class SurveyResponseViewModel
     {
         public int ResponseId { get; set; }
@@ -86,6 +94,7 @@ namespace JwtIdentity.Common.ViewModels
                     AnswerType.MultipleChoice => JsonSerializer.Deserialize<MultipleChoiceAnswerViewModel>(doc.RootElement.GetRawText(), options),
                     AnswerType.SingleChoice => JsonSerializer.Deserialize<SingleChoiceAnswerViewModel>(doc.RootElement.GetRawText(), options),
                     AnswerType.Rating1To10 => JsonSerializer.Deserialize<Rating1To10AnswerViewModel>(doc.RootElement.GetRawText(), options),
+                    AnswerType.SelectAllThatApply => JsonSerializer.Deserialize<SelectAllThatApplyAnswerViewModel>(doc.RootElement.GetRawText(), options),
                     _ => throw new NotSupportedException($"Unsupported AnswerType: {answerType}")
                 };
             }

--- a/JwtIdentity.Common/ViewModels/ChoiceOptionViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/ChoiceOptionViewModel.cs
@@ -3,7 +3,8 @@ namespace JwtIdentity.Common.ViewModels
     public class ChoiceOptionViewModel
     {
         public int Id { get; set; }
-        public int MultipleChoiceQuestionId { get; set; }
+        public int? MultipleChoiceQuestionId { get; set; }
+        public int? SelectAllThatApplyQuestionId { get; set; }
         public string OptionText { get; set; }
         public int Order { get; set; }
     }

--- a/JwtIdentity.Common/ViewModels/QuestionViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/QuestionViewModel.cs
@@ -33,6 +33,11 @@ namespace JwtIdentity.Common.ViewModels
     {
         public List<ChoiceOptionViewModel> Options { get; set; } = new List<ChoiceOptionViewModel>();
     }
+    
+    public class SelectAllThatApplyQuestionViewModel : QuestionViewModel
+    {
+        public List<ChoiceOptionViewModel> Options { get; set; } = new List<ChoiceOptionViewModel>();
+    }
 
     public class BaseQuestionDto
     {
@@ -43,7 +48,7 @@ namespace JwtIdentity.Common.ViewModels
         public QuestionType QuestionType { get; set; }
         public DateTime CreatedDate { get; set; }
         public DateTime UpdatedDate { get; set; }
-        // etc. — but *no* Answers or derived class fields
+        // etc. ï¿½ but *no* Answers or derived class fields
     }
 
     public class QuestionViewModelConverter : JsonConverter<QuestionViewModel>
@@ -60,6 +65,7 @@ namespace JwtIdentity.Common.ViewModels
                     QuestionType.TrueFalse => JsonSerializer.Deserialize<TrueFalseQuestionViewModel>(doc.RootElement.GetRawText(), options),
                     QuestionType.MultipleChoice => JsonSerializer.Deserialize<MultipleChoiceQuestionViewModel>(doc.RootElement.GetRawText(), options),
                     QuestionType.Rating1To10 => JsonSerializer.Deserialize<Rating1To10QuestionViewModel>(doc.RootElement.GetRawText(), options),
+                    QuestionType.SelectAllThatApply => JsonSerializer.Deserialize<SelectAllThatApplyQuestionViewModel>(doc.RootElement.GetRawText(), options),
                     _ => throw new NotSupportedException($"Unsupported QuestionType: {questionType}")
                 };
             }

--- a/JwtIdentity.Common/ViewModels/SurveyDataViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/SurveyDataViewModel.cs
@@ -15,6 +15,8 @@
         public MultipleChoiceQuestionViewModel MultipleChoiceQuestion { get; set; }
 
         public Rating1To10QuestionViewModel Rating1To10Question { get; set; }
+
+        public SelectAllThatApplyQuestionViewModel SelectAllThatApplyQuestion { get; set; }
     }
 
     public class ChartData

--- a/JwtIdentity/Configurations/MapperConfig.cs
+++ b/JwtIdentity/Configurations/MapperConfig.cs
@@ -42,6 +42,10 @@
             _ = CreateMap<Rating1To10QuestionViewModel, Rating1To10Question>()
                 .ForMember(x => x.CreatedBy, options => options.Ignore());
 
+            _ = CreateMap<SelectAllThatApplyQuestion, SelectAllThatApplyQuestionViewModel>()
+                .ForMember(dest => dest.Options, opt => opt.MapFrom(src => src.Options));
+            _ = CreateMap<SelectAllThatApplyQuestionViewModel, SelectAllThatApplyQuestion>()
+                .ForMember(x => x.CreatedBy, options => options.Ignore());
 
             _ = CreateMap<Answer, AnswerViewModel>().IncludeAllDerived();
             _ = CreateMap<AnswerViewModel, Answer>().IncludeAllDerived()
@@ -67,7 +71,14 @@
             _ = CreateMap<Rating1To10AnswerViewModel, Rating1To10Answer>()
                 .ForMember(x => x.CreatedBy, options => options.Ignore());
 
-            _ = CreateMap<ChoiceOption, ChoiceOptionViewModel>().ReverseMap();
+            _ = CreateMap<SelectAllThatApplyAnswer, SelectAllThatApplyAnswerViewModel>();
+            _ = CreateMap<SelectAllThatApplyAnswerViewModel, SelectAllThatApplyAnswer>()
+                .ForMember(x => x.CreatedBy, options => options.Ignore());
+
+            _ = CreateMap<ChoiceOption, ChoiceOptionViewModel>().ReverseMap()
+                .ForMember(dest => dest.MultipleChoiceQuestionId, opt => opt.MapFrom(src => src.MultipleChoiceQuestionId))
+                .ForMember(dest => dest.SelectAllThatApplyQuestionId, opt => opt.MapFrom(src => src.SelectAllThatApplyQuestionId));
+
 
             _ = CreateMap<Survey, SurveyViewModel>().ReverseMap();
         }

--- a/JwtIdentity/Controllers/QuestionController.cs
+++ b/JwtIdentity/Controllers/QuestionController.cs
@@ -32,6 +32,11 @@ namespace JwtIdentity.Controllers
                 var mcQuestion = await _context.Questions.OfType<MultipleChoiceQuestion>().Include(x => x.Options).FirstOrDefaultAsync(x => x.Id == id);
                 return Ok(_mapper.Map<QuestionViewModel>(mcQuestion));
             }
+            else if (question.QuestionType == QuestionType.SelectAllThatApply)
+            {
+                var selectAllQuestion = await _context.Questions.OfType<SelectAllThatApplyQuestion>().Include(x => x.Options).FirstOrDefaultAsync(x => x.Id == id);
+                return Ok(_mapper.Map<QuestionViewModel>(selectAllQuestion));
+            }
 
             return Ok(_mapper.Map<QuestionViewModel>(question));
         }
@@ -124,6 +129,11 @@ namespace JwtIdentity.Controllers
             {
                 var existingMCQuestion = await _context.Questions.OfType<MultipleChoiceQuestion>().AsNoTracking().Include(x => x.Options).FirstOrDefaultAsync(q => q.Id == id);
                 _context.ChoiceOptions.RemoveRange(existingMCQuestion.Options);
+            }
+            else if (question.QuestionType == QuestionType.SelectAllThatApply)
+            {
+                var existingSelectAllQuestion = await _context.Questions.OfType<SelectAllThatApplyQuestion>().AsNoTracking().Include(x => x.Options).FirstOrDefaultAsync(q => q.Id == id);
+                _context.ChoiceOptions.RemoveRange(existingSelectAllQuestion.Options);
             }
 
             _ = _context.Questions.Remove(question);

--- a/JwtIdentity/Data/ApplicationDbContext.cs
+++ b/JwtIdentity/Data/ApplicationDbContext.cs
@@ -127,7 +127,8 @@ namespace JwtIdentity.Data
                 .HasValue<TextQuestion>(QuestionType.Text)
                 .HasValue<TrueFalseQuestion>(QuestionType.TrueFalse)
                 .HasValue<MultipleChoiceQuestion>(QuestionType.MultipleChoice)
-                .HasValue<Rating1To10Question>(QuestionType.Rating1To10);
+                .HasValue<Rating1To10Question>(QuestionType.Rating1To10)
+                .HasValue<SelectAllThatApplyQuestion>(QuestionType.SelectAllThatApply);
 
             // TPH for Answers
             _ = builder.Entity<Answer>()
@@ -136,7 +137,20 @@ namespace JwtIdentity.Data
                 .HasValue<TrueFalseAnswer>(AnswerType.TrueFalse)
                 .HasValue<SingleChoiceAnswer>(AnswerType.SingleChoice)
                 .HasValue<MultipleChoiceAnswer>(AnswerType.MultipleChoice)
-                .HasValue<Rating1To10Answer>(AnswerType.Rating1To10);
+                .HasValue<Rating1To10Answer>(AnswerType.Rating1To10)
+                .HasValue<SelectAllThatApplyAnswer>(AnswerType.SelectAllThatApply);
+
+            _ = builder.Entity<ChoiceOption>()
+            .HasOne(co => co.MultipleChoiceQuestion)
+            .WithMany(mcq => mcq.Options)
+            .HasForeignKey(co => co.MultipleChoiceQuestionId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+            _ = builder.Entity<ChoiceOption>()
+                .HasOne(co => co.SelectAllThatApplyQuestion)
+                .WithMany(satq => satq.Options)
+                .HasForeignKey(co => co.SelectAllThatApplyQuestionId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
 
         public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/JwtIdentity/Migrations/20250406173223_AddSelectAllThatApplyQuestion.Designer.cs
+++ b/JwtIdentity/Migrations/20250406173223_AddSelectAllThatApplyQuestion.Designer.cs
@@ -4,6 +4,7 @@ using JwtIdentity.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace JwtIdentity.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250406173223_AddSelectAllThatApplyQuestion")]
+    partial class AddSelectAllThatApplyQuestion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -264,7 +267,7 @@ namespace JwtIdentity.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<int?>("MultipleChoiceQuestionId")
+                    b.Property<int>("MultipleChoiceQuestionId")
                         .HasColumnType("int");
 
                     b.Property<string>("OptionText")
@@ -698,19 +701,15 @@ namespace JwtIdentity.Migrations
 
             modelBuilder.Entity("JwtIdentity.Models.ChoiceOption", b =>
                 {
-                    b.HasOne("JwtIdentity.Models.MultipleChoiceQuestion", "MultipleChoiceQuestion")
+                    b.HasOne("JwtIdentity.Models.MultipleChoiceQuestion", null)
                         .WithMany("Options")
                         .HasForeignKey("MultipleChoiceQuestionId")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
-                    b.HasOne("JwtIdentity.Models.SelectAllThatApplyQuestion", "SelectAllThatApplyQuestion")
+                    b.HasOne("JwtIdentity.Models.SelectAllThatApplyQuestion", null)
                         .WithMany("Options")
-                        .HasForeignKey("SelectAllThatApplyQuestionId")
-                        .OnDelete(DeleteBehavior.Cascade);
-
-                    b.Navigation("MultipleChoiceQuestion");
-
-                    b.Navigation("SelectAllThatApplyQuestion");
+                        .HasForeignKey("SelectAllThatApplyQuestionId");
                 });
 
             modelBuilder.Entity("JwtIdentity.Models.Feedback", b =>

--- a/JwtIdentity/Migrations/20250406173223_AddSelectAllThatApplyQuestion.cs
+++ b/JwtIdentity/Migrations/20250406173223_AddSelectAllThatApplyQuestion.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JwtIdentity.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSelectAllThatApplyQuestion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SelectAllThatApplyQuestionId",
+                table: "ChoiceOptions",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SelectedOptionIds",
+                table: "Answers",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChoiceOptions_SelectAllThatApplyQuestionId",
+                table: "ChoiceOptions",
+                column: "SelectAllThatApplyQuestionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ChoiceOptions_Questions_SelectAllThatApplyQuestionId",
+                table: "ChoiceOptions",
+                column: "SelectAllThatApplyQuestionId",
+                principalTable: "Questions",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ChoiceOptions_Questions_SelectAllThatApplyQuestionId",
+                table: "ChoiceOptions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ChoiceOptions_SelectAllThatApplyQuestionId",
+                table: "ChoiceOptions");
+
+            migrationBuilder.DropColumn(
+                name: "SelectAllThatApplyQuestionId",
+                table: "ChoiceOptions");
+
+            migrationBuilder.DropColumn(
+                name: "SelectedOptionIds",
+                table: "Answers");
+        }
+    }
+}

--- a/JwtIdentity/Migrations/20250406181813_UpdateChoiceOptions.Designer.cs
+++ b/JwtIdentity/Migrations/20250406181813_UpdateChoiceOptions.Designer.cs
@@ -4,6 +4,7 @@ using JwtIdentity.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace JwtIdentity.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250406181813_UpdateChoiceOptions")]
+    partial class UpdateChoiceOptions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/JwtIdentity/Migrations/20250406181813_UpdateChoiceOptions.cs
+++ b/JwtIdentity/Migrations/20250406181813_UpdateChoiceOptions.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JwtIdentity.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateChoiceOptions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            _ = migrationBuilder.DropForeignKey(
+                name: "FK_ChoiceOptions_Questions_SelectAllThatApplyQuestionId",
+                table: "ChoiceOptions");
+
+            _ = migrationBuilder.AlterColumn<int>(
+                name: "MultipleChoiceQuestionId",
+                table: "ChoiceOptions",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            _ = migrationBuilder.AddForeignKey(
+                name: "FK_ChoiceOptions_Questions_SelectAllThatApplyQuestionId",
+                table: "ChoiceOptions",
+                column: "SelectAllThatApplyQuestionId",
+                principalTable: "Questions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.NoAction);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            _ = migrationBuilder.DropForeignKey(
+                name: "FK_ChoiceOptions_Questions_SelectAllThatApplyQuestionId",
+                table: "ChoiceOptions");
+
+            _ = migrationBuilder.AlterColumn<int>(
+                name: "MultipleChoiceQuestionId",
+                table: "ChoiceOptions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            _ = migrationBuilder.AddForeignKey(
+                name: "FK_ChoiceOptions_Questions_SelectAllThatApplyQuestionId",
+                table: "ChoiceOptions",
+                column: "SelectAllThatApplyQuestionId",
+                principalTable: "Questions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/JwtIdentity/Models/Answer.cs
+++ b/JwtIdentity/Models/Answer.cs
@@ -48,4 +48,12 @@
     {
         public int SelectedOptionId { get; set; }
     }
+
+    public class SelectAllThatApplyAnswer : Answer
+    {
+        // For select all that apply, we'll store selected options as a comma-separated string
+        // This will allow us to store multiple selections
+        public string SelectedOptionIds { get; set; }
+
+    }
 }

--- a/JwtIdentity/Models/ChoiceOption.cs
+++ b/JwtIdentity/Models/ChoiceOption.cs
@@ -3,10 +3,12 @@
     public class ChoiceOption
     {
         public int Id { get; set; }
-        public int MultipleChoiceQuestionId { get; set; }
-
+        public int? MultipleChoiceQuestionId { get; set; }
+        public int? SelectAllThatApplyQuestionId { get; set; }
         public string OptionText { get; set; }
-
         public int Order { get; set; }
+
+        public MultipleChoiceQuestion MultipleChoiceQuestion { get; set; }
+        public SelectAllThatApplyQuestion SelectAllThatApplyQuestion { get; set; }
     }
 }

--- a/JwtIdentity/Models/Question.cs
+++ b/JwtIdentity/Models/Question.cs
@@ -36,4 +36,10 @@ namespace JwtIdentity.Models
         // For multiple-choice, you might store a list of possible options
         public List<ChoiceOption> Options { get; set; }
     }
+
+    public class SelectAllThatApplyQuestion : Question
+    {
+        // For select-all-that-apply, store a list of possible options like multiple choice
+        public List<ChoiceOption> Options { get; set; }
+    }
 }


### PR DESCRIPTION
This commit introduces a new question type, "Select All That Apply," to the survey application. Key changes include:

- UI updates in `CreateQuestions.razor` for creating the new question type, including a modified button label.
- Logic enhancements in `CreateQuestions.razor.cs` for adding and validating the new question type.
- Creation of new view models: `SelectAllThatApplyQuestionViewModel` and `SelectAllThatApplyAnswerViewModel`.
- Updates to `AnswerType` and `QuestionType` enums to include the new type.
- Database schema modifications with migrations to support foreign key relationships for the new question type.
- Updates to `ApplicationDbContext`, `AnswerController`, and `QuestionController` to handle the new question type.
- Adjustments to `SurveyDataViewModel` and related classes to accommodate the new question type and its options.

These changes enhance survey functionality by allowing multiple selections in questions, improving usability.