### PR TITLE
Add preset choice selection to survey editing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,23 @@
+This is a blazor webassembly project that uses a server project that provides an API. 
+Both projects are in the same solution. They both use .Net9.
+The solution also contains a Common Library for shared functionality, which can be utilized across both the Blazor WebAssembly and the server project for consistency and code reuse.
+The common project contains ViewModels and static classes and helper methods that are used by the client and server project. This enhances maintainability and promotes a clean architecture in the solution.
+The solution uses cookie authentication and authorization for the Blazor WebAssembly project. Additionally, best practices are followed for security and performance optimizations.
+The Blazor WebAssembly project is configured to use the latest .NET 9 features and libraries, ensuring that it is up-to-date with the latest advancements in the .NET ecosystem.
+The solution is designed to be modular and scalable, allowing for easy addition of new features and components in the future.
+The project structure is organized to separate concerns, making it easier to manage and understand the codebase.
+The solution is built using the latest .NET 9 features and libraries, ensuring that it is up-to-date with the latest advancements in the .NET ecosystem.
+The server project uses ef core and has a database connection string in the appsettings.json file and appsettings.Development.json file. The connection string is used to connect to a SQL Server database.
+The database is created using ef core migrations, and the initial migration is included in the project. The database is created when the application is run for the first time, and the data is seeded with some initial data.
+When building datagrids, use Syncfusion Blazor components for data grids. Examples of how to use Syncfusion Blazor components are included in the project in LogsGrid.razor, ManageFeedback.razor, MyFeedback.razor, Filter.razor, SurveysIAnswered.razor, and SurverysICreated.razor.
+
+When creating razor components or blazor pages, always create razor.cs code behind files.
+The class name for the code behind file should be named the same as the razor component file, plus Model. For example, if the razor component file is named MyComponent.razor, the code behind file should be named MyComponentModel.razor.cs.
+The razor component file should inherit from the code behind file. For example, if the code behind file is named MyComponentModel.razor.cs, the razor component file should inherit from MyComponentModel.
+The code behind file should inherit from BlazorBase. All of the injected services are in the BlazorBase class. Do not inject services in the razor component file or the code behind file. Always use the injected services from BlazorBase.
+When creating a new dialog, always use examples from Pages\Admin\Dialogs and Pages\Common.
+When creating a <MudList, always add the T parameter as T="string". See Home.razor for an example, or Documentation.razor
+
+The API project uses AutoMapper for mapping between entities and DTOs. The mapping profiles are located in the API project, and the AutoMapper configuration is done in Configurations/MapperConfig.cs.
+The controller endpoints that take a body take and return Viewmodels. The ViewModels are located in the Common project. 
+The client project makes API calls using IApiService. Please review the methods in this file to understand how to make API calls. The IApiService is injected in the BlazorBase class, so you can use it directly in inherited Razor components and access API methods through dependency injection.

--- a/JwtIdentity.Client/Pages/Survey/EditSurvey.razor
+++ b/JwtIdentity.Client/Pages/Survey/EditSurvey.razor
@@ -50,6 +50,15 @@
                     {
                         <MudPaper>
                             <MudText Typo="Typo.h6" Class="mb-1">Add the Question Choices</MudText>
+
+                            <MudSelect Label="Preset Choices" T="string" @bind-Value="SelectedPresetChoice" Variant="Variant.Filled" Dense="true" Class="mb-2">
+                                <MudSelectItem T="string" Value=null>-- Select Preset --</MudSelectItem>
+                                @foreach (var preset in PresetChoices)
+                                {
+                                    <MudSelectItem Value="@preset.Key">@preset.Key</MudSelectItem>
+                                }
+                            </MudSelect>
+
                             <MudTextField id="Choice" Label="Choice Text" @bind-Value="NewChoiceOptionText" Variant="Variant.Filled" Lines="1" MaxLines="5" AutoGrow="true" Immediate="true" Counter="50" MaxLength="50" />
 
                             <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" OnClick="@AddChoiceOption" Disabled="@(string.IsNullOrWhiteSpace(NewChoiceOptionText))">Add Choice</MudButton>

--- a/JwtIdentity.Client/Pages/Survey/EditSurvey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/EditSurvey.razor.cs
@@ -43,11 +43,35 @@ namespace JwtIdentity.Client.Pages.Survey
 
         protected string NewChoiceOptionText { get; set; }
 
+        private string _selectedPresetChoice = string.Empty;
+        protected string SelectedPresetChoice
+        {
+            get => _selectedPresetChoice;
+            set
+            {
+                if (_selectedPresetChoice != value)
+                {
+                    _selectedPresetChoice = value;
+                    var preset = PresetChoices.FirstOrDefault(x => x.Key == value);
+                    if (preset.Key != null && preset.Options != null)
+                    {
+                        MultipleChoiceQuestion.Options.Clear();
+                        int i = 0;
+                        foreach (var option in preset.Options)
+                        {
+                            MultipleChoiceQuestion.Options.Add(new ChoiceOptionViewModel { OptionText = option, Order = i++ });
+                        }
+                    }
+                }
+            }
+        }
+        protected List<(string Key, List<string> Options)> PresetChoices => ChoiceOptionHelper.PresetChoices;
+
         protected bool AddQuestionToSurveyDisabled =>
             Survey.Published ||
             string.IsNullOrWhiteSpace(QuestionText) ||
-            ((SelectedQuestionType.Replace(" ", "") == Enum.GetName(QuestionType.MultipleChoice) || 
-              SelectedQuestionType.Replace(" ", "") == Enum.GetName(QuestionType.SelectAllThatApply)) && 
+            ((SelectedQuestionType.Replace(" ", "") == Enum.GetName(QuestionType.MultipleChoice) ||
+              SelectedQuestionType.Replace(" ", "") == Enum.GetName(QuestionType.SelectAllThatApply)) &&
               MultipleChoiceQuestion.Options.Count == 0);
 
         protected MudExpansionPanel ExistingQuestionPanel { get; set; }
@@ -229,14 +253,11 @@ namespace JwtIdentity.Client.Pages.Survey
                         {
                             SelectedQuestion.Text = QuestionText;
                             SelectedQuestion.IsRequired = IsRequired;
-
                             _ = Survey.Questions.Remove(questionToUpdate);
                             Survey.Questions.Add(SelectedQuestion);
                         }
                     }
-
                     break;
-                    
                 case "SelectAllThatApply":
                     if ((SelectedQuestion?.Id ?? 0) == 0)
                     {
@@ -336,7 +357,7 @@ namespace JwtIdentity.Client.Pages.Survey
 
             if (SelectedExistingQuestion == null)
             {
-                SelectedQuestion = Survey.Questions.FirstOrDefault(x => x.Id == input.Id);                
+                SelectedQuestion = Survey.Questions.FirstOrDefault(x => x.Id == input.Id);
             }
 
             if (SelectedQuestion != null)
@@ -497,7 +518,7 @@ namespace JwtIdentity.Client.Pages.Survey
 
         protected async Task UpdateTitleDescription(string value, string type)
         {
-            if(string.IsNullOrWhiteSpace(value) || value.Length < 5)
+            if (string.IsNullOrWhiteSpace(value) || value.Length < 5)
             {
                 // Show error message if title or description is empty or too short
                 _ = Snackbar.Add("Title/Description must be at least 5 characters long", MudBlazor.Severity.Error);
@@ -512,8 +533,8 @@ namespace JwtIdentity.Client.Pages.Survey
             {
                 Survey.Description = value;
             }
-        
-        
+
+
             if (await UpdateSurvey())
             {
                 _ = Snackbar.Add("Update Successful", MudBlazor.Severity.Success);

--- a/JwtIdentity.Common/Helpers/ChoiceOptionHelper.cs
+++ b/JwtIdentity.Common/Helpers/ChoiceOptionHelper.cs
@@ -1,0 +1,25 @@
+namespace JwtIdentity.Common.Helpers
+{
+    public static class ChoiceOptionHelper
+    {
+        public static readonly List<(string Key, List<string> Options)> PresetChoices = new()
+        {
+            ("How Likely", new List<string> { "Extremely likely", "Likely", "Neutral", "Unlikely", "Extremely unlikely" }),
+            ("How Satisfied", new List<string> { "Very satisfied", "Satisfied", "Neutral", "Dissatisfied", "Very dissatisfied" }),
+            ("Excellent to Poor", new List<string> { "Excellent", "Good", "Average", "Poor", "Very poor" }),
+            ("Yes No Partially", new List<string> { "Yes", "No", "Partially" }),
+            ("Yes No", new List<string> { "Yes", "No" }),
+            ("True False", new List<string> { "True", "False" }),
+            ("Agree Disagree", new List<string> { "Strongly agree", "Agree", "Neutral", "Disagree", "Strongly disagree" }),
+            ("Very Important to Not Important", new List<string> { "Very important", "Important", "Neutral", "Not important" }),
+            ("Faster to Slower", new List<string> {"Faster than expected", "As expected", "Slower than expected"}),
+            ("Very Easy to Very Difficult", new List<string> {"Very easy", "Easy", "Neutral", "Difficult", "Very difficult"}),
+            ("Excellent Value to Poor Value", new List<string> {"Excellent value", "Good value", "Neutral", "Poor value", "Very poor value"}),
+            ("Very Helpful to Not Helpful", new List<string> {"Very helpful", "Helpful", "Neutral", "Not helpful"}),
+            ("Very Clear to Not Clear", new List<string> {"Very clear", "Clear", "Neutral", "Not clear"}),
+            ("Very Engaging to Not Engaging", new List<string> {"Very engaging", "Engaging", "Neutral", "Not engaging"}),
+            ("Very Relevant to Not Relevant", new List<string> {"Very relevant", "Relevant", "Neutral", "Not relevant"}),
+            ("Extremely Valuable to Not Valuable", new List<string> {"Extremely valuable", "Valuable", "Neutral", "Not valuable"})
+        };
+    }
+}

--- a/JwtIdentity.Common/Helpers/QuestionType.cs
+++ b/JwtIdentity.Common/Helpers/QuestionType.cs
@@ -6,6 +6,6 @@
         TrueFalse = 2,
         MultipleChoice = 3,
         Rating1To10 = 4,
-        SelectAllThatApply = 5,
+        SelectAllThatApply = 5
     }
 }

--- a/JwtIdentity.sln
+++ b/JwtIdentity.sln
@@ -1,4 +1,5 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.12.35707.178
 MinimumVisualStudioVersion = 16.0.0.0
@@ -11,6 +12,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JwtIdentity.Tests", "JwtIdentity.Tests\JwtIdentity.Tests.csproj", "{91F0365E-E306-42C2-BB95-62365439F249}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JwtIdentity.BunitTests", "bUnitTests\JwtIdentity.BunitTests.csproj", "{39F02D5C-B7CC-4A43-ADD0-35A83C3A00B9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
+	ProjectSection(SolutionItems) = preProject
+		.github\copilot-instructions.md = .github\copilot-instructions.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
- Introduced a `MudSelect` component for selecting preset choices and a `MudTextField` for custom input in `EditSurvey.razor`.
- Added `SelectedPresetChoice` property and logic to update `MultipleChoiceQuestion.Options` based on the selected preset.
- Updated `AddQuestionToSurveyDisabled` logic to account for multiple choice options.
- Introduced `_selectedPresetChoice` in `EditSurvey.razor.cs` to back the new property and retrieve preset choices from `ChoiceOptionHelper`.
- Minor update to `QuestionType.cs` to retain `SelectAllThatApply` enum value.
- Updated `JwtIdentity.sln` to include a project section for solution items and added `copilot-instructions.md` for project guidelines.
- Created `ChoiceOptionHelper.cs` with a static class for maintaining preset choices, improving code reusability.