### PR TITLE
Add NoAuthClient for unauthenticated API requests

### DIFF
--- a/JwtIdentity.Client/Program.cs
+++ b/JwtIdentity.Client/Program.cs
@@ -67,4 +67,7 @@ builder.Services.AddHttpClient("AuthorizedClient", client =>
 
 builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("AuthorizedClient"));
 
+// Register a named HttpClient called "NoAuthClient" for unauthenticated requests
+builder.Services.AddHttpClient("NoAuthClient");
+
 await builder.Build().RunAsync();


### PR DESCRIPTION
Introduce a new named `HttpClient` called "NoAuthClient" for unauthenticated requests in `Program.cs`. Update `WordPressBlogService` to use `IHttpClientFactory` for better management of `HttpClient` instances. Refactor `GetAllPostsAsync` and `GetPostByPostSlugAsync` methods to utilize "NoAuthClient" for WordPress API requests. Remove logging statements for a more streamlined error handling approach.