### PR TITLE
Enable prerendering for Blazor components

### DIFF
--- a/JwtIdentity.Tests/ConfigurationTests/MapperConfigTests.cs
+++ b/JwtIdentity.Tests/ConfigurationTests/MapperConfigTests.cs
@@ -17,7 +17,7 @@ namespace JwtIdentity.Tests.ConfigurationTests
         [SetUp]
         public void SetUp()
         {
-            var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperConfig>());
+            var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperConfig>(), null);
             _mapper = config.CreateMapper();
         }
 

--- a/JwtIdentity/Components/App.razor
+++ b/JwtIdentity/Components/App.razor
@@ -31,11 +31,11 @@
     <link rel="stylesheet" href="@Assets["css/app.css"]" />
     <ImportMap />
     <link rel="icon" type="image/png" href="images/icon.png" />
-    <HeadOutlet @rendermode=" new InteractiveWebAssemblyRenderMode(prerender:false)" />
+    <HeadOutlet @rendermode=" new InteractiveWebAssemblyRenderMode(prerender:true)" />
 </head>
 
 <body>
-    <Routes @rendermode=" new InteractiveWebAssemblyRenderMode(prerender:false)" />
+    <Routes @rendermode=" new InteractiveWebAssemblyRenderMode(prerender:true)" />
     <div id="fb-root"></div>
     <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v22.0&appId=1209050230789265"></script>
     <script src="js/site.js"></script>    


### PR DESCRIPTION
## Summary
- Enable prerendering in `App.razor` for `<HeadOutlet>` and `<Routes>`
- Initialize AutoMapper in `MapperConfigTests` with explicit logger factory to satisfy new constructor requirements

## Testing
- `dotnet build`
- `dotnet test` *(fails: System.ArgumentOutOfRangeException from Microsoft.Build.Logging.TerminalLogger)*

------
https://chatgpt.com/codex/tasks/task_e_688eb127e82c832a9e7dc81415c0a8a1