### PR TITLE
Add server guard for authentication state provider

### DIFF
--- a/JwtIdentity.Client/Services/CustomAuthStateProvider.cs
+++ b/JwtIdentity.Client/Services/CustomAuthStateProvider.cs
@@ -28,6 +28,11 @@ namespace JwtIdentity.Client.Services
         public override async Task<AuthenticationState> GetAuthenticationStateAsync()
         {
             var user = new ClaimsPrincipal(new ClaimsIdentity());
+            if (!OperatingSystem.IsBrowser())
+            {
+                return new AuthenticationState(user);
+            }
+
             var savedToken = await _localStorage.GetItemAsync<string>("authToken");
             if (savedToken == null)
             {
@@ -95,6 +100,11 @@ namespace JwtIdentity.Client.Services
 
         private async Task<List<Claim>> GetClaims()
         {
+            if (!OperatingSystem.IsBrowser())
+            {
+                return new List<Claim>();
+            }
+
             var savedToken = await _localStorage.GetItemAsync<string>("authToken");
             var tokenContent = this.jwtSecurityTokenHandler.ReadJwtToken(savedToken);
             var claims = tokenContent.Claims.ToList();


### PR DESCRIPTION
## Summary
- Avoid local storage on the server by checking `OperatingSystem.IsBrowser()`
- Return unauthenticated state and empty claims when not in a browser

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688ebfc96444832ab312cda31cd4641e