### PR TITLE
Gate captcha JS calls to browser

### DIFF
--- a/JwtIdentity.Client/Pages/BlazorBase.cs
+++ b/JwtIdentity.Client/Pages/BlazorBase.cs
@@ -1,5 +1,6 @@
 ﻿using Blazored.LocalStorage;
 using JwtIdentity.Client.Helpers;
+using Microsoft.Extensions.Logging;
 
 namespace JwtIdentity.Client.Pages
 {
@@ -44,6 +45,9 @@ namespace JwtIdentity.Client.Pages
 
         [Inject]
         internal IUtility Utility { get; set; }
+
+        [Inject]
+        internal ILogger<BlazorBase> Logger { get; set; }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     }
 }

--- a/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http.Json;
 using System.Security.Claims;
+using Microsoft.Extensions.Logging;
 
 namespace JwtIdentity.Client.Pages.Survey
 {
@@ -56,11 +57,15 @@ namespace JwtIdentity.Client.Pages.Survey
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (firstRender)
+            if (firstRender && OperatingSystem.IsBrowser())
             {
                 await JSRuntime.InvokeVoidAsync("registerCaptchaCallback", objRef);
                 // Call JavaScript to manually render the widget in the container with your site key.
                 await JSRuntime.InvokeVoidAsync("renderReCaptcha", "captcha-container", Configuration["ReCaptcha:SiteKey"]);
+            }
+            else if (firstRender)
+            {
+                Logger?.LogWarning("OperatingSystem.IsBrowser() returned false; captcha not rendered.");
             }
         }
 


### PR DESCRIPTION
## Summary
- Ensure ReCaptcha JS runs only in browser contexts.
- Add `ILogger<SurveyModel>` injection for diagnostic logging when not in a browser.
- Inject logger into `BlazorBase` so all pages can log without per-page injection.

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688ecab38aec832a862b9d4a9ac1a16c