### PR TITLE
Delay MudBlazor services until NavigationManager is initialized

### DIFF
--- a/JwtIdentity.Client/Layout/MainLayout.razor
+++ b/JwtIdentity.Client/Layout/MainLayout.razor
@@ -1,7 +1,6 @@
 ﻿@inherits LayoutComponentBase
 @using System.Security.Claims
 @inject AuthenticationStateProvider AuthStateProvider
-@inject HttpClient Client
 @inject IJSRuntime JSRuntime
 @inject ILocalStorageService LocalStorage
 @inject IUtility Utility

--- a/JwtIdentity.Client/Pages/BlazorBase.cs
+++ b/JwtIdentity.Client/Pages/BlazorBase.cs
@@ -1,4 +1,4 @@
-﻿using Blazored.LocalStorage;
+using Blazored.LocalStorage;
 using JwtIdentity.Client.Helpers;
 using Microsoft.Extensions.Logging;
 
@@ -6,15 +6,12 @@ namespace JwtIdentity.Client.Pages
 {
     public class BlazorBase : ComponentBase
     {
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+#pragma warning disable CS8618
         [Inject]
         internal NavigationManager NavigationManager { get; set; }
 
         [Inject]
         internal IApiService ApiService { get; set; }
-
-        [Inject]
-        internal ISnackbar Snackbar { get; set; }
 
         [Inject]
         internal IAuthService AuthService { get; set; }
@@ -26,13 +23,10 @@ namespace JwtIdentity.Client.Pages
         internal AuthenticationStateProvider AuthStateProvider { get; set; }
 
         [Inject]
-        internal CustomAuthorizationMessageHandler CustomAuthorizationMessageHandler { get; set; }
+        internal IHttpClientFactory HttpClientFactory { get; set; }
 
         [Inject]
-        internal HttpClient Client { get; set; }
-
-        [Inject]
-        internal NavigationManager Navigation { get; set; }
+        internal IServiceProvider ServiceProvider { get; set; }
 
         [Inject]
         internal IJSRuntime JSRuntime { get; set; }
@@ -48,6 +42,16 @@ namespace JwtIdentity.Client.Pages
 
         [Inject]
         internal ILogger<BlazorBase> Logger { get; set; }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+#pragma warning restore CS8618
+
+        private HttpClient? _client;
+        protected HttpClient Client => _client ??= HttpClientFactory.CreateClient("AuthorizedClient");
+
+        protected ISnackbar Snackbar => ServiceProvider.GetRequiredService<ISnackbar>();
+
+        protected CustomAuthorizationMessageHandler CustomAuthorizationMessageHandler => ServiceProvider.GetRequiredService<CustomAuthorizationMessageHandler>();
+
+        protected NavigationManager Navigation => NavigationManager;
     }
 }
+

--- a/JwtIdentity.Client/Program.cs
+++ b/JwtIdentity.Client/Program.cs
@@ -11,13 +11,7 @@ builder.Configuration
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
-builder.Services.AddScoped<IApiService, ApiService>(sp =>
-{
-    var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
-    var navigationManager = sp.GetRequiredService<NavigationManager>();
-    var snackbar = sp.GetRequiredService<ISnackbar>();
-    return new ApiService(httpClientFactory, navigationManager, snackbar);
-});
+builder.Services.AddScoped<IApiService, ApiService>();
 
 Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("Ngo9BigBOggjHTQxAR8/V1NNaF5cXmBCf1FpRmJGdld5fUVHYVZUTXxaS00DNHVRdkdmWXtecnZUQ2NdUkZzWENWYUA=");
 
@@ -65,7 +59,6 @@ builder.Services.AddHttpClient("AuthorizedClient", client =>
 })
 .AddHttpMessageHandler<CustomAuthorizationMessageHandler>();
 
-builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("AuthorizedClient"));
 
 // Register a named HttpClient called "NoAuthClient" for unauthenticated requests
 builder.Services.AddHttpClient("NoAuthClient");

--- a/JwtIdentity.Client/Services/CustomAuthorizationMessageHandler.cs
+++ b/JwtIdentity.Client/Services/CustomAuthorizationMessageHandler.cs
@@ -1,16 +1,20 @@
-﻿namespace JwtIdentity.Client.Services
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JwtIdentity.Client.Services
 {
     public class CustomAuthorizationMessageHandler : DelegatingHandler
     {
         private readonly NavigationManager _navigationManager;
-        private readonly ISnackbar snackbar;
+        private readonly IServiceProvider serviceProvider;
+
+        private ISnackbar Snackbar => serviceProvider.GetRequiredService<ISnackbar>();
 
         public event Action OnUnauthorized;
 
-        public CustomAuthorizationMessageHandler(NavigationManager navigationManager, ISnackbar snackbar)
+        public CustomAuthorizationMessageHandler(NavigationManager navigationManager, IServiceProvider serviceProvider)
         {
             _navigationManager = navigationManager;
-            this.snackbar = snackbar;
+            this.serviceProvider = serviceProvider;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -25,10 +29,11 @@
             else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
                 _navigationManager.NavigateTo("/");
-                _ = snackbar.Add("The page does not exist.", Severity.Error);
+                _ = Snackbar.Add("The page does not exist.", Severity.Error);
             }
 
             return response;
         }
     }
 }
+

--- a/JwtIdentity/Program.cs
+++ b/JwtIdentity/Program.cs
@@ -154,14 +154,7 @@ builder.Services.AddHttpClient("NoAuthClient", (sp, client) =>
     var request = accessor.HttpContext?.Request;
     client.BaseAddress = new Uri($"{request?.Scheme}://{request?.Host}");
 });
-builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("AuthorizedClient"));
-builder.Services.AddScoped<IApiService, ApiService>(sp =>
-{
-    var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
-    var navigationManager = sp.GetRequiredService<NavigationManager>();
-    var snackbar = sp.GetRequiredService<ISnackbar>();
-    return new ApiService(httpClientFactory, navigationManager, snackbar);
-});
+builder.Services.AddScoped<IApiService, ApiService>();
 // Replace the existing line with the following line
 builder.Services.AddAutoMapper(cfg => cfg.AddProfile<MapperConfig>());
 builder.Services.AddAuthentication(options =>

--- a/bUnitTests/BUnitTestBase.cs
+++ b/bUnitTests/BUnitTestBase.cs
@@ -27,6 +27,7 @@ namespace JwtIdentity.BunitTests
         protected Mock<ISnackbar> SnackbarMock { get; private set; }
         protected Mock<IDialogService> DialogServiceMock { get; private set; }
         protected Mock<IApiService> ApiServiceMock { get; private set; }
+        protected Mock<IHttpClientFactory> HttpClientFactoryMock { get; private set; }
         
         public BUnitTestBase()
         {
@@ -47,6 +48,8 @@ namespace JwtIdentity.BunitTests
             SnackbarMock = new Mock<ISnackbar>();
             DialogServiceMock = new Mock<IDialogService>();
             ApiServiceMock = new Mock<IApiService>();
+            HttpClientFactoryMock = new Mock<IHttpClientFactory>();
+            HttpClientFactoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(new HttpClient());
             var authStateProviderMock = new Mock<AuthenticationStateProvider>();
             
             // Register services to the test context
@@ -56,6 +59,7 @@ namespace JwtIdentity.BunitTests
             Context.Services.AddSingleton<IDialogService>(DialogServiceMock.Object);
             Context.Services.AddSingleton<IApiService>(ApiServiceMock.Object);
             Context.Services.AddSingleton<AuthenticationStateProvider>(authStateProviderMock.Object);
+            Context.Services.AddSingleton<IHttpClientFactory>(HttpClientFactoryMock.Object);
 
             // Register a fake for CustomAuthorizationMessageHandler
             Context.Services.AddSingleton<JwtIdentity.Client.Services.CustomAuthorizationMessageHandler>(new FakeCustomAuthorizationMessageHandler());
@@ -76,7 +80,7 @@ namespace JwtIdentity.BunitTests
         // Fake implementation for DI
         private class FakeCustomAuthorizationMessageHandler : JwtIdentity.Client.Services.CustomAuthorizationMessageHandler
         {
-            public FakeCustomAuthorizationMessageHandler() : base(null, null) { }
+            public FakeCustomAuthorizationMessageHandler() : base(new MockNavigationManager(), new ServiceCollection().BuildServiceProvider()) { }
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid pre-render failures by deferring creation of MudBlazor Snackbar and HttpClient-based services until NavigationManager is ready
- refactor ApiService, CustomAuthStateProvider, and CustomAuthorizationMessageHandler to resolve ISnackbar/HttpClient lazily
- clean up base components and tests to use IHttpClientFactory and service provider

## Testing
- `/tmp/dotnet9/dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688ed88b5270832a8bb4ee9400f9fb30