### PR TITLE
Ensure MudBlazor assets are available during prerendering

### DIFF
--- a/JwtIdentity/JwtIdentity.csproj
+++ b/JwtIdentity/JwtIdentity.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="8.2.2" />
     <PackageReference Include="Serilog.Sinks.RollingFileAlternate" Version="2.0.9" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="MudBlazor" Version="8.10.0" />
     <ProjectReference Include="..\JwtIdentity.Client\JwtIdentity.Client.csproj" />
     <ProjectReference Include="..\JwtIdentity.Common\JwtIdentity.Common.csproj" />
     <PackageReference Include="AutoMapper" Version="15.0.1" />


### PR DESCRIPTION
## Summary
- include MudBlazor package in server project so its static assets load during prerendering

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688eddd75ba0832a916c9c561956e701