### PR TITLE
Fix nav menu disposal error

### DIFF
--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
@@ -3,6 +3,8 @@
     public class MyNavMenuModel : BlazorBase, IDisposable
     {
         private bool _disposed = false;
+        // Cache handler to ensure subscriptions don't resolve services after disposal
+        private CustomAuthorizationMessageHandler? _authorizationHandler;
 
         [Parameter]
         public bool DarkTheme { get; set; }
@@ -14,7 +16,8 @@
         protected override void OnInitialized()
         {
             ((CustomAuthStateProvider)AuthStateProvider!).OnLoggedOut += UpdateLoggedIn;
-            CustomAuthorizationMessageHandler.OnUnauthorized += UpdateLoggedIn;
+            _authorizationHandler = CustomAuthorizationMessageHandler;
+            _authorizationHandler.OnUnauthorized += UpdateLoggedIn;
             _drawerOpen = false;
         }
 
@@ -41,7 +44,10 @@
                 if (disposing)
                 {
                     ((CustomAuthStateProvider)AuthStateProvider!).OnLoggedOut -= UpdateLoggedIn;
-                    CustomAuthorizationMessageHandler.OnUnauthorized -= UpdateLoggedIn;
+                    if (_authorizationHandler != null)
+                    {
+                        _authorizationHandler.OnUnauthorized -= UpdateLoggedIn;
+                    }
                 }
                 _disposed = true;
             }


### PR DESCRIPTION
## Summary
- cache `CustomAuthorizationMessageHandler` in `MyNavMenu` to avoid resolving services after DI container disposal
- unsubscribe using cached handler when component is disposed

## Testing
- `/root/.dotnet/dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688ee23b7d74832ab999cfc6e7da7279