### PR TITLE
fix: remove render mode from HeadOutlet to resolve blazor comment error

### DIFF
--- a/JwtIdentity/Components/App.razor
+++ b/JwtIdentity/Components/App.razor
@@ -31,7 +31,7 @@
     <link rel="stylesheet" href="@Assets["css/app.css"]" />
     <ImportMap />
     <link rel="icon" type="image/png" href="images/icon.png" />
-    <HeadOutlet @rendermode=" new InteractiveWebAssemblyRenderMode(prerender:true)" />
+    <HeadOutlet />
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- fix malformed component comment by removing unnecessary render mode from HeadOutlet

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688ee62b6b10832ab23aef2ed73252a6