### PR TITLE
Load Syncfusion license from configuration

### DIFF
--- a/JwtIdentity.Client/Program.cs
+++ b/JwtIdentity.Client/Program.cs
@@ -2,6 +2,7 @@ using Blazored.LocalStorage;
 using JwtIdentity.Client.Helpers;
 using JwtIdentity.Services;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Syncfusion.Licensing;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
@@ -11,9 +12,13 @@ builder.Configuration
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
-builder.Services.AddScoped<IApiService, ApiService>();
+  builder.Services.AddScoped<IApiService, ApiService>();
 
-Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("Ngo9BigBOggjHTQxAR8/V1NNaF5cXmBCf1FpRmJGdld5fUVHYVZUTXxaS00DNHVRdkdmWXtecnZUQ2NdUkZzWENWYUA=");
+  var syncfusionLicense = builder.Configuration["Syncfusion:LicenseKey"];
+  if (!string.IsNullOrWhiteSpace(syncfusionLicense))
+  {
+      SyncfusionLicenseProvider.RegisterLicense(syncfusionLicense);
+  }
 
 builder.Services.AddSyncfusionBlazor();
 builder.Services.AddBlazoredLocalStorage();

--- a/JwtIdentity.Client/wwwroot/appsettings.json
+++ b/JwtIdentity.Client/wwwroot/appsettings.json
@@ -7,5 +7,8 @@
   },
   "ReCaptcha": {
     "SiteKey": "6Ld2Pe8qAAAAACv1fURb8pIP0QDkX14TRLkZcd2l"
+  },
+  "Syncfusion": {
+    "LicenseKey": ""
   }
 }

--- a/JwtIdentity/Program.cs
+++ b/JwtIdentity/Program.cs
@@ -121,7 +121,11 @@ builder.Services.AddScoped<IApiAuthService, ApiAuthService>();
 builder.Services.AddScoped<ISurveyService, SurveyService>();
 builder.Services.AddScoped<JwtIdentity.Services.BackgroundJobs.BackgroundJobService>();
 // Services required for prerendering shared client components
-SyncfusionLicenseProvider.RegisterLicense("Ngo9BigBOggjHTQxAR8/V1NNaF5cXmBCf1FpRmJGdld5fUVHYVZUTXxaS00DNHVRdkdmWXtecnZUQ2NdUkZzWENWYUA=");
+var syncfusionLicense = builder.Configuration["Syncfusion:LicenseKey"];
+if (!string.IsNullOrWhiteSpace(syncfusionLicense))
+{
+    SyncfusionLicenseProvider.RegisterLicense(syncfusionLicense);
+}
 builder.Services.AddSyncfusionBlazor();
 builder.Services.AddBlazoredLocalStorage();
 builder.Services.AddCascadingAuthenticationState();

--- a/JwtIdentity/appsettings.json
+++ b/JwtIdentity/appsettings.json
@@ -9,5 +9,8 @@
   "FeedbackSettings": {
     "AdminNotificationEmails": [],
     "NotificationsSnoozeUntil": null
+  },
+  "Syncfusion": {
+    "LicenseKey": ""
   }
 }


### PR DESCRIPTION
## Summary
- read Syncfusion license key from config before registering on server
- register Syncfusion license on the client as well and pull key from config
- add Syncfusion license placeholders to appsettings for server and client

## Testing
- `dotnet build` *(fails: current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688f6d235984832a8c6afa504e051f98