### PR TITLE
fix: persist auth on server prerender

### DIFF
--- a/JwtIdentity.Client/JwtIdentity.Client.csproj
+++ b/JwtIdentity.Client/JwtIdentity.Client.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.7" />

--- a/JwtIdentity.Client/Services/CustomAuthStateProvider.cs
+++ b/JwtIdentity.Client/Services/CustomAuthStateProvider.cs
@@ -2,6 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
 
 namespace JwtIdentity.Client.Services
 {
@@ -11,6 +12,7 @@ namespace JwtIdentity.Client.Services
         private readonly IServiceProvider _serviceProvider;
         private readonly JwtSecurityTokenHandler jwtSecurityTokenHandler;
         private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IHttpContextAccessor? _httpContextAccessor;
         public HttpClient _httpClient { get; set; }
 
         public ApplicationUserViewModel CurrentUser { get; set; }
@@ -20,12 +22,18 @@ namespace JwtIdentity.Client.Services
         private IApiService ApiService => _serviceProvider.GetRequiredService<IApiService>();
 
         public CustomAuthStateProvider(Blazored.LocalStorage.ILocalStorageService localStorage, IHttpClientFactory httpClientFactory, IServiceProvider serviceProvider)
+            : this(localStorage, httpClientFactory, serviceProvider, null)
+        {
+        }
+
+        public CustomAuthStateProvider(Blazored.LocalStorage.ILocalStorageService localStorage, IHttpClientFactory httpClientFactory, IServiceProvider serviceProvider, IHttpContextAccessor? httpContextAccessor)
         {
             _localStorage = localStorage;
             jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
 
             _httpClientFactory = httpClientFactory;
             _serviceProvider = serviceProvider;
+            _httpContextAccessor = httpContextAccessor;
         }
 
         public override async Task<AuthenticationState> GetAuthenticationStateAsync()
@@ -34,8 +42,22 @@ namespace JwtIdentity.Client.Services
 
             if (!OperatingSystem.IsBrowser())
             {
-                return new AuthenticationState(anonymous);
+                var token = _httpContextAccessor?.HttpContext?.Request.Cookies["authToken"];
+                if (string.IsNullOrEmpty(token))
+                {
+                    return new AuthenticationState(anonymous);
+                }
 
+                var tokenContent = jwtSecurityTokenHandler.ReadJwtToken(token);
+                if (tokenContent.ValidTo < DateTime.UtcNow)
+                {
+                    return new AuthenticationState(anonymous);
+                }
+
+                var claims = tokenContent.Claims.ToList();
+                claims.Add(new Claim(ClaimTypes.Name, tokenContent.Subject));
+                var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "jwt"));
+                return new AuthenticationState(user);
             }
 
             var savedToken = await _localStorage.GetItemAsync<string>("authToken");


### PR DESCRIPTION
## Summary
- allow server prerender to honor auth cookie for JWT
- expose IHttpContextAccessor in CustomAuthStateProvider
- reference ASP.NET Core Http abstractions in client project

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found; requested 9.0.100)*

------
https://chatgpt.com/codex/tasks/task_e_688f8fd445e0832aa396372471553783