### PR TITLE
fix: persist auth on server prerender

### DIFF
--- a/JwtIdentity.Client/JwtIdentity.Client.csproj
+++ b/JwtIdentity.Client/JwtIdentity.Client.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.7" />


### PR DESCRIPTION
## Summary
- allow server prerender to honor auth cookie for JWT
- expose IHttpContextAccessor in CustomAuthStateProvider
- reference ASP.NET Core Http abstractions in client project
- resolve server-side variable name conflicts in auth provider

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found; requested 9.0.100)*

------
https://chatgpt.com/codex/tasks/task_e_688f8fd445e0832aa396372471553783