### PR TITLE
fix: persist auth on server prerender

### DIFF
--- a/JwtIdentity.Client/JwtIdentity.Client.csproj
+++ b/JwtIdentity.Client/JwtIdentity.Client.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.7" />

--- a/JwtIdentity.Client/Services/CustomAuthStateProvider.cs
+++ b/JwtIdentity.Client/Services/CustomAuthStateProvider.cs
@@ -2,6 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
 
 namespace JwtIdentity.Client.Services
 {
@@ -11,6 +12,7 @@ namespace JwtIdentity.Client.Services
         private readonly IServiceProvider _serviceProvider;
         private readonly JwtSecurityTokenHandler jwtSecurityTokenHandler;
         private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IHttpContextAccessor? _httpContextAccessor;
         public HttpClient _httpClient { get; set; }
 
         public ApplicationUserViewModel CurrentUser { get; set; }
@@ -20,12 +22,18 @@ namespace JwtIdentity.Client.Services
         private IApiService ApiService => _serviceProvider.GetRequiredService<IApiService>();
 
         public CustomAuthStateProvider(Blazored.LocalStorage.ILocalStorageService localStorage, IHttpClientFactory httpClientFactory, IServiceProvider serviceProvider)
+            : this(localStorage, httpClientFactory, serviceProvider, null)
+        {
+        }
+
+        public CustomAuthStateProvider(Blazored.LocalStorage.ILocalStorageService localStorage, IHttpClientFactory httpClientFactory, IServiceProvider serviceProvider, IHttpContextAccessor? httpContextAccessor)
         {
             _localStorage = localStorage;
             jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
 
             _httpClientFactory = httpClientFactory;
             _serviceProvider = serviceProvider;
+            _httpContextAccessor = httpContextAccessor;
         }
 
         public override async Task<AuthenticationState> GetAuthenticationStateAsync()
@@ -34,8 +42,32 @@ namespace JwtIdentity.Client.Services
 
             if (!OperatingSystem.IsBrowser())
             {
-                return new AuthenticationState(anonymous);
+                var token = _httpContextAccessor?.HttpContext?.Request.Cookies["authToken"];
+                if (string.IsNullOrEmpty(token))
+                {
+                    return new AuthenticationState(anonymous);
+                }
 
+                var serverToken = jwtSecurityTokenHandler.ReadJwtToken(token);
+                if (serverToken.ValidTo < DateTime.UtcNow)
+                {
+                    return new AuthenticationState(anonymous);
+                }
+
+                _httpClient ??= _httpClientFactory.CreateClient("AuthorizedClient");
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+                var serverClaims = serverToken.Claims.ToList();
+                serverClaims.Add(new Claim(ClaimTypes.Name, serverToken.Subject));
+                var serverUser = new ClaimsPrincipal(new ClaimsIdentity(serverClaims, "jwt"));
+
+                var serverUserId = serverClaims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
+                if (!string.IsNullOrEmpty(serverUserId))
+                {
+                    CurrentUser = await ApiService.GetAsync<ApplicationUserViewModel>($"{ApiEndpoints.ApplicationUser}/{serverUserId}");
+                }
+
+                return new AuthenticationState(serverUser);
             }
 
             var savedToken = await _localStorage.GetItemAsync<string>("authToken");


### PR DESCRIPTION
## Summary
- allow server prerender to honor auth cookie for JWT
- expose IHttpContextAccessor in CustomAuthStateProvider
- reference ASP.NET Core Http abstractions in client project
- resolve server-side variable name conflicts in auth provider
- forward auth cookie to server-side API calls and guard against unexpected HTML responses

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found; requested 9.0.100)*

------
https://chatgpt.com/codex/tasks/task_e_688f8fd445e0832aa396372471553783