### PR TITLE
Fix date format in sitemap.xml

### DIFF
--- a/JwtIdentity/wwwroot/sitemap.xml
+++ b/JwtIdentity/wwwroot/sitemap.xml
@@ -8,7 +8,7 @@
 	</url>
 	<url>
 		<loc>https://surveyshark.site/documentation</loc>
-		<lastmod>2025-8-03</lastmod>
+		<lastmod>2025-08-03</lastmod>
 		<changefreq>monthly</changefreq>
 		<priority>0.6</priority>
 	</url>


### PR DESCRIPTION
Updated the `<lastmod>` tag for the URL
`https://surveyshark.site/documentation` to use a
two-digit month format, changing it from `2025-8-03` to `2025-08-03`.