### PR TITLE
feat: add OpenAI survey generation service

### DIFF
--- a/JwtIdentity.Common/ViewModels/OpenAiSurveyRequest.cs
+++ b/JwtIdentity.Common/ViewModels/OpenAiSurveyRequest.cs
@@ -1,0 +1,7 @@
+namespace JwtIdentity.Common.ViewModels
+{
+    public class OpenAiSurveyRequest
+    {
+        public string Description { get; set; }
+    }
+}

--- a/JwtIdentity/Controllers/OpenAiController.cs
+++ b/JwtIdentity/Controllers/OpenAiController.cs
@@ -1,0 +1,46 @@
+using JwtIdentity.Common.ViewModels;
+using JwtIdentity.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JwtIdentity.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class OpenAiController : ControllerBase
+    {
+        private readonly IOpenAi _openAiService;
+        private readonly ILogger<OpenAiController> _logger;
+
+        public OpenAiController(IOpenAi openAiService, ILogger<OpenAiController> logger)
+        {
+            _openAiService = openAiService;
+            _logger = logger;
+        }
+
+        [HttpPost("generate")]
+        public async Task<ActionResult<SurveyViewModel>> GenerateSurvey([FromBody] OpenAiSurveyRequest request)
+        {
+            if (request == null || string.IsNullOrWhiteSpace(request.Description))
+            {
+                return BadRequest();
+            }
+
+            try
+            {
+                var survey = await _openAiService.GenerateSurveyAsync(request.Description);
+                if (survey == null)
+                {
+                    return StatusCode(StatusCodes.Status502BadGateway, "Unable to generate survey");
+                }
+
+                return Ok(survey);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error generating survey from OpenAI");
+                return StatusCode(StatusCodes.Status500InternalServerError, "Error generating survey");
+            }
+        }
+    }
+}

--- a/JwtIdentity/Program.cs
+++ b/JwtIdentity/Program.cs
@@ -4,6 +4,7 @@ using Hangfire.SqlServer;
 using JwtIdentity.Client.Helpers;
 using JwtIdentity.Client.Services;
 using JwtIdentity.Middleware;
+using JwtIdentity.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Components;
@@ -120,6 +121,7 @@ builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddScoped<IApiAuthService, ApiAuthService>();
 builder.Services.AddScoped<ISurveyService, SurveyService>();
 builder.Services.AddScoped<JwtIdentity.Services.BackgroundJobs.BackgroundJobService>();
+builder.Services.AddHttpClient<IOpenAi, OpenAiService>();
 // Services required for prerendering shared client components
 var syncfusionLicense = builder.Configuration["Syncfusion:LicenseKey"];
 if (!string.IsNullOrWhiteSpace(syncfusionLicense))

--- a/JwtIdentity/Services/IOpenAi.cs
+++ b/JwtIdentity/Services/IOpenAi.cs
@@ -1,0 +1,9 @@
+using JwtIdentity.Common.ViewModels;
+
+namespace JwtIdentity.Services
+{
+    public interface IOpenAi
+    {
+        Task<SurveyViewModel> GenerateSurveyAsync(string description);
+    }
+}


### PR DESCRIPTION
## Summary
- integrate OpenAI service using HttpClient to request survey questions from OpenAI
- expose new OpenAIController endpoint returning generated SurveyViewModel
- register OpenAI service in dependency injection
- align OpenAI service interface and implementation with repository's non-nullable conventions

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68955102dd54832a855956d5273a1419