### PR TITLE
Render nav menu on first load

### DIFF
--- a/JwtIdentity.Client/Layout/MainLayout.razor
+++ b/JwtIdentity.Client/Layout/MainLayout.razor
@@ -107,9 +107,9 @@
 
     IJSObjectReference? module;
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (!OperatingSystem.IsBrowser())
+        if (!firstRender || !OperatingSystem.IsBrowser())
         {
             return;
         }

--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
@@ -5,13 +5,13 @@
     <MudImage Src="images/logo_200_60.png" />
     <MudSpacer />
 
-    <MudHidden Breakpoint="Breakpoint.SmAndDown">
+    <div class="d-none d-md-flex">
         <MudSwitch Value="@DarkTheme" Label="Dark Theme" ValueChanged="DarkThemeChanged" />
-    </MudHidden>
-    <MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
-        <MudSwitch Value="@DarkTheme" Label="Dark Theme" ValueChanged="DarkThemeChanged" Size="MudBlazor.Size.Small"  />
-    </MudHidden>
-    <MudHidden Breakpoint="Breakpoint.SmAndDown">
+    </div>
+    <div class="d-md-none">
+        <MudSwitch Value="@DarkTheme" Label="Dark Theme" ValueChanged="DarkThemeChanged" Size="MudBlazor.Size.Small" />
+    </div>
+    <div class="d-none d-md-flex align-items-center">
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mx-2" Href="/">Home</MudButton>
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mx-2" Href="/blogs">Blogs</MudButton>
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mx-2" Href="/documentation">Documentation</MudButton>
@@ -61,7 +61,7 @@
                 </NotAuthorized>
             </AuthorizeView>
         </div>
-    </MudHidden>    
+    </div>
 </MudAppBar>
 
 <MudDrawer @bind-Open="_drawerOpen" Anchor="MudBlazor.Anchor.Left" Variant="DrawerVariant.Temporary" Elevation="1">

--- a/JwtIdentity/Components/App.razor
+++ b/JwtIdentity/Components/App.razor
@@ -29,6 +29,8 @@
     
     <link rel="stylesheet" href="@Assets["JwtIdentity.styles.css"]" />
     <link rel="stylesheet" href="@Assets["css/app.css"]" />
+    <link rel="stylesheet" href="css/app-light.css" class="theme" />
+    <link rel="stylesheet" href="css/bootstrap5.3.css" class="theme" />
     <ImportMap />
     <link rel="icon" type="image/png" href="images/icon.png" />
     <HeadOutlet />


### PR DESCRIPTION
## Summary
- Replace MudHidden with responsive CSS classes so navigation items show before breakpoint JS loads

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6898ecba5a9c832abc399b7fe7f79aba