### PR TITLE
Update MudButton styles to Variant.Filled

### DIFF
--- a/JwtIdentity.Client/Pages/Admin/Settings/SettingDialog.razor
+++ b/JwtIdentity.Client/Pages/Admin/Settings/SettingDialog.razor
@@ -42,8 +42,8 @@
         </MudGrid>
     </DialogContent>
     <DialogActions>
-        <MudButton OnClick="Cancel">Cancel</MudButton>
-        <MudButton Color="Color.Primary" OnClick="Submit" Disabled="@(!IsValid())">Save</MudButton>
+        <MudButton OnClick="Cancel" Variant="Variant.Filled">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit" Disabled="@(!IsValid())">Save</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/JwtIdentity.Client/Pages/Auth/Register.razor
+++ b/JwtIdentity.Client/Pages/Auth/Register.razor
@@ -20,7 +20,7 @@
         <MudText Typo="Typo.body2">and</MudText>
         <MudLink Href="/privacy-policy" Target="_blank">Privacy Policy</MudLink>  
     </MudStack>
-    <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Disabled="@(!AgreedToTerms)">Register</MudButton>
+    <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!AgreedToTerms)">Register</MudButton>
 </EditForm>
 
 @code {

--- a/JwtIdentity.Client/Pages/Common/SpinnerButton.razor
+++ b/JwtIdentity.Client/Pages/Common/SpinnerButton.razor
@@ -1,5 +1,5 @@
 @inherits JwtIdentity.Client.Pages.Common.SpinnerButtonModel
-<MudButton OnClick="@OnClick" Disabled="@(IsBusy || Disabled)" ButtonType="@ButtonType" Color="@Color">
+<MudButton OnClick="@OnClick" Disabled="@(IsBusy || Disabled)" ButtonType="@ButtonType" Color="@Color" Variant="Variant.Filled">
     @if (IsBusy)
     {
         <MudProgressCircular Indeterminate="true" Size="MudBlazor.Size.Small" Class="me-2" />

--- a/JwtIdentity.Client/Pages/Feedback/LeaveFeedback.razor
+++ b/JwtIdentity.Client/Pages/Feedback/LeaveFeedback.razor
@@ -29,7 +29,7 @@
             </MudForm>
         </MudCardContent>
         <MudCardActions>
-            <MudButton OnClick="@Cancel" Variant="Variant.Outlined" Color="Color.Secondary" Class="ml-auto">Cancel</MudButton>
+            <MudButton OnClick="@Cancel" Variant="Variant.Filled" Color="Color.Secondary" Class="ml-auto">Cancel</MudButton>
             <MudButton OnClick="@Submit" Disabled="@(!success)" Variant="Variant.Filled" Color="Color.Primary" Class="ml-2">Submit</MudButton>
         </MudCardActions>
     </MudCard>


### PR DESCRIPTION
Enhanced the visual appearance of buttons across multiple Razor components by updating `MudButton` elements to use the `Variant.Filled` style. This includes the `Cancel` and `Save` buttons in `SettingDialog.razor`, the `Register` button in `Register.razor`, and the `Cancel` button in `LeaveFeedback.razor`. The `SpinnerButton.razor` component has also been updated to reflect this style change.