### PR TITLE
feat: add admin user management

### DIFF
--- a/JwtIdentity.Client/Pages/Admin/Dialogs/EditUserDialog.razor
+++ b/JwtIdentity.Client/Pages/Admin/Dialogs/EditUserDialog.razor
@@ -1,0 +1,41 @@
+@using JwtIdentity.Common.ViewModels
+@using JwtIdentity.Common.Helpers
+@inherits EditUserDialogModel
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">@(User.Id == 0 ? "Add User" : $"Edit User: {User.UserName}")</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudForm @ref="_form">
+            <MudTextField @bind-Value="User.UserName" Label="Username" Required="true" />
+            <MudTextField @bind-Value="User.Email" Label="Email" />
+            <MudTextField @bind-Value="User.PhoneNumber" Label="Phone Number" />
+            <MudCheckBox T="bool" @bind-Checked="User.EmailConfirmed" Label="Email Confirmed" />
+            <MudCheckBox T="bool" @bind-Checked="User.PhoneNumberConfirmed" Label="Phone Confirmed" />
+            <MudCheckBox T="bool" @bind-Checked="User.TwoFactorEnabled" Label="Two Factor Enabled" />
+            <MudDatePicker @bind-Date="lockoutDate" Label="Lockout End" />
+            <MudCheckBox T="bool" @bind-Checked="User.LockoutEnabled" Label="Lockout Enabled" />
+            <MudNumericField T="int" @bind-Value="User.AccessFailedCount" Label="Access Failed Count" />
+            <MudTextField @bind-Value="User.Theme" Label="Theme" />
+            <MudText Typo="Typo.subtitle2" Class="mt-2">Roles</MudText>
+            <MudChipSet T="string">
+                @foreach (var role in User.Roles)
+                {
+                    <MudChip Color="Color.Primary" Size="MudBlazor.Size.Small" OnClose="@((MudChip<string> _) => RemoveRole(role))" Closeable="true">@role</MudChip>
+                }
+            </MudChipSet>
+            <MudSelect T="string" @bind-Value="SelectedRole" Label="Add Role">
+                @foreach (var role in AvailableRoles)
+                {
+                    <MudSelectItem Value="@role">@role</MudSelectItem>
+                }
+            </MudSelect>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="AddRole" Disabled="@string.IsNullOrEmpty(SelectedRole)" Class="mt-1">Add Role</MudButton>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="!CanSave" OnClick="Save">Save</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/JwtIdentity.Client/Pages/Admin/Dialogs/EditUserDialogModel.cs
+++ b/JwtIdentity.Client/Pages/Admin/Dialogs/EditUserDialogModel.cs
@@ -1,0 +1,62 @@
+using JwtIdentity.Common.ViewModels;
+using JwtIdentity.Common.Helpers;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace JwtIdentity.Client.Pages.Admin.Dialogs
+{
+    public class EditUserDialogModel : BlazorBase
+    {
+        [CascadingParameter] private IMudDialogInstance MudDialogInstance { get; set; } = default!;
+        [Parameter] public ApplicationUserViewModel User { get; set; } = new();
+        [Parameter] public List<ApplicationUserViewModel> AllUsers { get; set; } = new();
+
+        protected MudForm _form = default!;
+        protected List<string> AllRoles { get; set; } = new();
+        protected string SelectedRole { get; set; } = string.Empty;
+        protected IEnumerable<string> AvailableRoles => AllRoles.Where(r => !User.Roles.Contains(r));
+        protected DateTime? lockoutDate;
+
+        protected override async Task OnInitializedAsync()
+        {
+            var roles = await ApiService.GetAsync<List<ApplicationRoleViewModel>>($"{ApiEndpoints.Auth}/GetRolesAndPermissions");
+            AllRoles = roles?.Select(r => r.Name).ToList() ?? new();
+            lockoutDate = User.LockoutEnd?.DateTime;
+        }
+
+        protected bool CanSave => !string.IsNullOrWhiteSpace(User.UserName) &&
+                                  User.Roles.Any() &&
+                                  !AllUsers.Any(u => u.UserName.Equals(User.UserName, StringComparison.OrdinalIgnoreCase) && u.Id != User.Id);
+
+        protected void AddRole()
+        {
+            if (!string.IsNullOrEmpty(SelectedRole) && !User.Roles.Contains(SelectedRole))
+            {
+                User.Roles.Add(SelectedRole);
+                SelectedRole = string.Empty;
+            }
+        }
+
+        protected void RemoveRole(string role) => User.Roles.Remove(role);
+
+        protected async Task Save()
+        {
+            await _form.Validate();
+            if (!CanSave || !_form.IsValid)
+            {
+                return;
+            }
+
+            if (User.Id == 0)
+            {
+                User.Password = "mypassword";
+            }
+
+            User.LockoutEnd = lockoutDate.HasValue ? new DateTimeOffset(lockoutDate.Value) : null;
+
+            MudDialogInstance.Close(DialogResult.Ok(User));
+        }
+
+        protected void Cancel() => MudDialogInstance.Cancel();
+    }
+}

--- a/JwtIdentity.Client/Pages/Admin/ManageUsers.razor
+++ b/JwtIdentity.Client/Pages/Admin/ManageUsers.razor
@@ -1,0 +1,61 @@
+@page "/admin/users"
+@attribute [Authorize(Roles = "Admin")]
+@inherits ManageUsersModel
+
+<PageTitle>Survey Shark - Manage Users</PageTitle>
+
+<MudContainer Class="mt-4 px-8" MaxWidth="MaxWidth.ExtraLarge">
+    <MudText Typo="Typo.h4" Class="mb-4">Manage Users</MudText>
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(async () => await AddUser())" Class="mb-2">Add User</MudButton>
+    @if (_loading)
+    {
+        <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+        <MudText Class="ml-2">Loading users...</MudText>
+    }
+    else
+    {
+        <MudPaper Class="pa-4">
+            <SfGrid DataSource="@Users" AllowPaging="true" AllowSorting="true" AllowFiltering="true" AllowResizing="true" FrozenColumns="@FrozenColumns" AllowTextWrap="true" TextWrapSettings="@GridSettings.TextWrapSettings" GridLines="@GridSettings.GridLines">
+                <GridFilterSettings Type="Syncfusion.Blazor.Grids.FilterType.Excel"></GridFilterSettings>
+                <GridColumns>
+                    <GridColumn HeaderText="Actions" Width="120" AllowSorting="false" AllowFiltering="false" AllowResizing="false" AllowReordering="false">
+                        <Template Context="userContext">
+                            @{ var user = userContext as ApplicationUserViewModel; }
+                            @if (user != null)
+                            {
+                                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="MudBlazor.Size.Small" Color="Color.Primary" OnClick="@(async () => await OpenUserDialog(user))" />
+                            }
+                        </Template>
+                    </GridColumn>
+                    <GridColumn Field="Id" HeaderText="ID" Width="80" TextAlign="TextAlign.Center" />
+                    <GridColumn Field="UserName" HeaderText="Username" Width="150" />
+                    <GridColumn Field="NormalizedUserName" HeaderText="Normalized Username" Width="200" />
+                    <GridColumn Field="Email" HeaderText="Email" Width="200" />
+                    <GridColumn Field="NormalizedEmail" HeaderText="Normalized Email" Width="200" />
+                    <GridColumn Field="EmailConfirmed" HeaderText="Email Confirmed" Width="130" Type="ColumnType.Boolean" />
+                    <GridColumn Field="PhoneNumber" HeaderText="Phone" Width="150" />
+                    <GridColumn Field="PhoneNumberConfirmed" HeaderText="Phone Confirmed" Width="150" Type="ColumnType.Boolean" />
+                    <GridColumn Field="TwoFactorEnabled" HeaderText="2FA" Width="80" Type="ColumnType.Boolean" />
+                    <GridColumn Field="LockoutEnd" HeaderText="Lockout End" Width="170" Type="ColumnType.DateTime" Format="G" />
+                    <GridColumn Field="LockoutEnabled" HeaderText="Lockout Enabled" Width="150" Type="ColumnType.Boolean" />
+                    <GridColumn Field="AccessFailedCount" HeaderText="Access Failed" Width="120" />
+                    <GridColumn Field="Theme" HeaderText="Theme" Width="120" />
+                    <GridColumn Field="CreatedDate" HeaderText="Created" Width="170" Type="ColumnType.DateTime" Format="G" />
+                    <GridColumn Field="UpdatedDate" HeaderText="Updated" Width="170" Type="ColumnType.DateTime" Format="G" />
+                    <GridColumn Field="RolesDisplay" HeaderText="Roles" Width="200" AllowSorting="false">
+                        <Template Context="userContext">
+                            @{ var user = userContext as ApplicationUserViewModel; }
+                            @if (user != null)
+                            {
+                                foreach (var role in user.Roles)
+                                {
+                                    <MudChip T="string" Size="MudBlazor.Size.Small">@role</MudChip>
+                                }
+                            }
+                        </Template>
+                    </GridColumn>
+                </GridColumns>
+            </SfGrid>
+        </MudPaper>
+    }
+</MudContainer>

--- a/JwtIdentity.Client/Pages/Admin/ManageUsersModel.cs
+++ b/JwtIdentity.Client/Pages/Admin/ManageUsersModel.cs
@@ -1,0 +1,73 @@
+using JwtIdentity.Common.ViewModels;
+using JwtIdentity.Common.Helpers;
+using JwtIdentity.Client.Pages.Admin.Dialogs;
+using MudBlazor;
+
+namespace JwtIdentity.Client.Pages.Admin
+{
+    public class ManageUsersModel : BlazorBase
+    {
+        protected List<ApplicationUserViewModel> Users { get; set; } = new();
+        protected bool _loading = true;
+
+        // Syncfusion Grid properties
+        protected int FrozenColumns { get; set; } = 1;
+
+        protected override async Task OnInitializedAsync()
+        {
+            await LoadUsers();
+        }
+
+        private async Task LoadUsers()
+        {
+            _loading = true;
+            Users = await ApiService.GetAsync<List<ApplicationUserViewModel>>(ApiEndpoints.ApplicationUser);
+            _loading = false;
+        }
+
+        protected async Task OpenUserDialog(ApplicationUserViewModel user)
+        {
+            var parameters = new DialogParameters
+            {
+                ["User"] = new ApplicationUserViewModel
+                {
+                    Id = user.Id,
+                    UserName = user.UserName,
+                    Email = user.Email,
+                    PhoneNumber = user.PhoneNumber,
+                    EmailConfirmed = user.EmailConfirmed,
+                    PhoneNumberConfirmed = user.PhoneNumberConfirmed,
+                    NormalizedEmail = user.NormalizedEmail,
+                    NormalizedUserName = user.NormalizedUserName,
+                    TwoFactorEnabled = user.TwoFactorEnabled,
+                    LockoutEnd = user.LockoutEnd,
+                    LockoutEnabled = user.LockoutEnabled,
+                    AccessFailedCount = user.AccessFailedCount,
+                    Theme = user.Theme,
+                    CreatedDate = user.CreatedDate,
+                    UpdatedDate = user.UpdatedDate,
+                    Roles = new List<string>(user.Roles)
+                },
+                ["AllUsers"] = Users
+            };
+
+            var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.Medium, FullWidth = true, CloseOnEscapeKey = true };
+            var dialog = await MudDialog.ShowAsync<EditUserDialog>(user.Id == 0 ? "Add User" : "Edit User", parameters, options);
+            var result = await dialog.Result;
+            if (!result.Canceled && result.Data is ApplicationUserViewModel model)
+            {
+                if (model.Id == 0)
+                {
+                    await ApiService.PostAsync<ApplicationUserViewModel>(ApiEndpoints.ApplicationUser, model);
+                }
+                else
+                {
+                    await ApiService.UpdateAsync($"{ApiEndpoints.ApplicationUser}/{model.Id}", model);
+                }
+                await LoadUsers();
+            }
+        }
+
+        protected Task AddUser() => OpenUserDialog(new ApplicationUserViewModel());
+    }
+}

--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
@@ -18,7 +18,8 @@
         <AuthorizeView Roles="Admin">
             <Authorized>
                 <MudMenu Label="Admin" Variant="Variant.Text" EndIcon="@Icons.Material.Filled.KeyboardArrowDown" Color="Color.Inherit">
-                    <MudMenuItem Href="/admin/feedback">Manage Feedback</MudMenuItem>                    
+                    <MudMenuItem Href="/admin/feedback">Manage Feedback</MudMenuItem>
+                    <MudMenuItem Href="/admin/users">Manage Users</MudMenuItem>
                     <MudMenuItem Href="/admin/settings">Settings Management</MudMenuItem>
                     <MudMenuItem Href="/admin/logs">System Logs</MudMenuItem>
                     <MudMenuItem Href="/ManageRolePermissions">Manage Permissions</MudMenuItem>
@@ -83,6 +84,7 @@
             <Authorized>
                 <MudNavGroup Title="Admin" Expanded="false">
                     <MudNavLink Href="/admin/feedback">Manage Feedback</MudNavLink>
+                    <MudNavLink Href="/admin/users">Manage Users</MudNavLink>
                     <MudNavLink Href="/admin/settings">Settings Management</MudNavLink>
                     <MudNavLink Href="/admin/logs">System Logs</MudNavLink>
                     <MudNavLink Href="/ManageRolePermissions">Manage Permissions</MudNavLink>

--- a/JwtIdentity.Common/ViewModels/ApplicationUserViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/ApplicationUserViewModel.cs
@@ -1,29 +1,41 @@
-﻿namespace JwtIdentity.Common.ViewModels
+using System.Text.Json.Serialization;
+
+namespace JwtIdentity.Common.ViewModels
 {
     public class ApplicationUserViewModel
     {
-        // insert all properties from IdentityUser<TKey> here
         public int Id { get; set; }
         public string UserName { get; set; }
         public string Email { get; set; }
         public string PhoneNumber { get; set; }
+
+        [JsonIgnore]
         public string PasswordHash { get; set; }
+
+        [JsonIgnore]
         public string SecurityStamp { get; set; }
+
+        [JsonIgnore]
         public string ConcurrencyStamp { get; set; }
+
         public bool EmailConfirmed { get; set; }
         public bool PhoneNumberConfirmed { get; set; }
         public string NormalizedEmail { get; set; }
         public string NormalizedUserName { get; set; }
-        public string TwoFactorEnabled { get; set; }
-        public string LockoutEnd { get; set; }
-        public string LockoutEnabled { get; set; }
-        public string AccessFailedCount { get; set; }
+        public bool TwoFactorEnabled { get; set; }
+        public DateTimeOffset? LockoutEnd { get; set; }
+        public bool LockoutEnabled { get; set; }
+        public int AccessFailedCount { get; set; }
 
         public string Theme { get; set; }
         public string Token { get; set; }
         public string Password { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public DateTime UpdatedDate { get; set; }
 
-        public List<string> Roles { get; set; } = new List<string>();
-        public List<string> Permissions { get; set; } = new List<string>();
+        public List<string> Roles { get; set; } = new();
+        public List<string> Permissions { get; set; } = new();
+
+        public string RolesDisplay => string.Join(", ", Roles);
     }
 }

--- a/JwtIdentity.Tests/TestBase.cs
+++ b/JwtIdentity.Tests/TestBase.cs
@@ -28,6 +28,7 @@ namespace JwtIdentity.Tests
     {
         // Common mocks that will be used across test classes
         protected Mock<UserManager<ApplicationUser>> MockUserManager = null!;
+        protected Mock<RoleManager<ApplicationRole>> MockRoleManager = null!;
         protected Mock<SignInManager<ApplicationUser>> MockSignInManager = null!;
         protected Mock<IConfiguration> MockConfiguration = null!;
         protected Mock<IMapper> MockMapper = null!;
@@ -52,6 +53,10 @@ namespace JwtIdentity.Tests
             MockUserManager = new Mock<UserManager<ApplicationUser>>(
                 userStoreMock.Object, null, null, null, null, null, null, null, null);
             
+            // Setup RoleManager mock
+            var roleStoreMock = new Mock<IRoleStore<ApplicationRole>>();
+            MockRoleManager = new Mock<RoleManager<ApplicationRole>>(roleStoreMock.Object, null, null, null, null);
+
             // Setup SignInManager mock
             var contextAccessorMock = new Mock<IHttpContextAccessor>();
             var userPrincipalFactoryMock = new Mock<IUserClaimsPrincipalFactory<ApplicationUser>>();

--- a/JwtIdentity/Configurations/MapperConfig.cs
+++ b/JwtIdentity/Configurations/MapperConfig.cs
@@ -10,11 +10,11 @@
             _ = CreateMap<BaseViewModel, BaseModel>()
                 .ForMember(x => x.CreatedBy, options => options.Ignore());
 
-            _ = CreateMap<ApplicationUser, ApplicationUserViewModel>().ReverseMap();
-            _ = CreateMap<ApplicationUserViewModel, ApplicationUser>()
-                .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.UserName))
-                .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.Email))
-                .ForMember(dest => dest.Theme, opt => opt.MapFrom(src => src.Theme));
+            _ = CreateMap<ApplicationUser, ApplicationUserViewModel>()
+                .ReverseMap()
+                .ForMember(dest => dest.PasswordHash, opt => opt.Ignore())
+                .ForMember(dest => dest.SecurityStamp, opt => opt.Ignore())
+                .ForMember(dest => dest.ConcurrencyStamp, opt => opt.Ignore());
 
             // Updated mapping for ApplicationRole and RoleClaim
             _ = CreateMap<ApplicationRole, ApplicationRoleViewModel>()

--- a/JwtIdentity/Controllers/ApplicationUsersController.cs
+++ b/JwtIdentity/Controllers/ApplicationUsersController.cs
@@ -8,16 +8,38 @@
         private readonly IMapper _mapper;
         private readonly IApiAuthService _apiAuthService;
         private readonly ILogger<ApplicationUserController> _logger;
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly RoleManager<ApplicationRole> _roleManager;
 
-        public ApplicationUserController(ApplicationDbContext context, IMapper mapper, IApiAuthService apiAuthService, ILogger<ApplicationUserController> logger)
+        public ApplicationUserController(ApplicationDbContext context, IMapper mapper, IApiAuthService apiAuthService, ILogger<ApplicationUserController> logger, UserManager<ApplicationUser> userManager, RoleManager<ApplicationRole> roleManager)
         {
             _context = context;
             _mapper = mapper;
             _apiAuthService = apiAuthService;
             _logger = logger;
+            _userManager = userManager;
+            _roleManager = roleManager;
         }
 
-        // GET: api/ApplicationUsers/5
+        // GET: api/ApplicationUser
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<ApplicationUserViewModel>>> GetApplicationUsers()
+        {
+            _logger.LogInformation("Getting all application users");
+
+            var users = await _context.ApplicationUsers.ToListAsync();
+            var result = new List<ApplicationUserViewModel>();
+            foreach (var user in users)
+            {
+                var vm = _mapper.Map<ApplicationUserViewModel>(user);
+                vm.Roles = (await _userManager.GetRolesAsync(user)).ToList();
+                result.Add(vm);
+            }
+
+            return Ok(result);
+        }
+
+        // GET: api/ApplicationUser/5
         [HttpGet("{id}")]
         public async Task<ActionResult<ApplicationUserViewModel>> GetApplicationUser(int id)
         {
@@ -35,9 +57,8 @@
 
                 _logger.LogDebug("Found user: {UserId}, {UserName}", applicationUser.Id, applicationUser.UserName);
 
-                // Map the ApplicationUser to ApplicationUserViewModel
                 ApplicationUserViewModel applicationUserViewModel = _mapper.Map<ApplicationUserViewModel>(applicationUser);
-                applicationUserViewModel.Roles = await _apiAuthService.GetUserRoles(User);
+                applicationUserViewModel.Roles = (await _userManager.GetRolesAsync(applicationUser)).ToList();
                 applicationUserViewModel.Permissions = _apiAuthService.GetUserPermissions(User);
 
                 _logger.LogInformation("Successfully retrieved user with ID {UserId}", id);
@@ -55,13 +76,12 @@
             }
         }
 
-        // PUT: api/ApplicationUsers/5
-        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        // PUT: api/ApplicationUser/5
         [HttpPut("{id}")]
         public async Task<IActionResult> PutApplicationUser(int id, ApplicationUserViewModel applicationUserViewModel)
         {
             _logger.LogInformation("Updating application user with ID {UserId}", id);
-            
+
             try
             {
                 if (applicationUserViewModel == null)
@@ -69,11 +89,26 @@
                     _logger.LogWarning("Received null application user view model for ID {UserId}", id);
                     return BadRequest("User data is required");
                 }
-                
+
                 if (id != applicationUserViewModel.Id)
                 {
                     _logger.LogWarning("ID mismatch: URL ID {UrlId} does not match model ID {ModelId}", id, applicationUserViewModel.Id);
                     return BadRequest("ID in URL must match ID in the request body");
+                }
+
+                if (string.IsNullOrWhiteSpace(applicationUserViewModel.UserName))
+                {
+                    return BadRequest("Username is required");
+                }
+
+                if (applicationUserViewModel.Roles == null || !applicationUserViewModel.Roles.Any())
+                {
+                    return BadRequest("At least one role is required");
+                }
+
+                if (await _context.ApplicationUsers.AnyAsync(u => u.UserName == applicationUserViewModel.UserName && u.Id != id))
+                {
+                    return BadRequest("Username already exists");
                 }
 
                 var applicationUser = await _context.ApplicationUsers.FindAsync(id);
@@ -83,16 +118,36 @@
                     return NotFound();
                 }
 
-                _logger.LogDebug("Found user to update: {UserId}, {UserName}", applicationUser.Id, applicationUser.UserName);
-
-                // Map updated fields from the view model to the existing entity
-                _mapper.Map(applicationUserViewModel, applicationUser);
+                applicationUser.UserName = applicationUserViewModel.UserName;
+                applicationUser.NormalizedUserName = _userManager.NormalizeName(applicationUserViewModel.UserName);
+                applicationUser.Email = applicationUserViewModel.Email;
+                applicationUser.NormalizedEmail = _userManager.NormalizeEmail(applicationUserViewModel.Email);
+                applicationUser.PhoneNumber = applicationUserViewModel.PhoneNumber;
+                applicationUser.EmailConfirmed = applicationUserViewModel.EmailConfirmed;
+                applicationUser.PhoneNumberConfirmed = applicationUserViewModel.PhoneNumberConfirmed;
+                applicationUser.TwoFactorEnabled = applicationUserViewModel.TwoFactorEnabled;
+                applicationUser.LockoutEnd = applicationUserViewModel.LockoutEnd;
+                applicationUser.LockoutEnabled = applicationUserViewModel.LockoutEnabled;
+                applicationUser.AccessFailedCount = applicationUserViewModel.AccessFailedCount;
+                applicationUser.Theme = applicationUserViewModel.Theme;
                 applicationUser.UpdatedDate = DateTime.UtcNow;
-                _logger.LogDebug("Updated user properties and set UpdatedDate to {UpdatedDate}", applicationUser.UpdatedDate);
 
                 try
                 {
                     await _context.SaveChangesAsync();
+
+                    var currentRoles = await _userManager.GetRolesAsync(applicationUser);
+                    var rolesToAdd = applicationUserViewModel.Roles.Except(currentRoles);
+                    var rolesToRemove = currentRoles.Except(applicationUserViewModel.Roles);
+                    if (rolesToAdd.Any())
+                    {
+                        await _userManager.AddToRolesAsync(applicationUser, rolesToAdd);
+                    }
+                    if (rolesToRemove.Any())
+                    {
+                        await _userManager.RemoveFromRolesAsync(applicationUser, rolesToRemove);
+                    }
+
                     _logger.LogInformation("Successfully updated user with ID {UserId}", id);
                     return NoContent();
                 }
@@ -120,6 +175,47 @@
                 _logger.LogError(ex, "Error updating user {UserId}: {Message}", id, ex.Message);
                 return StatusCode(StatusCodes.Status500InternalServerError, "An unexpected error occurred. Please try again later.");
             }
+        }
+
+        // POST: api/ApplicationUser
+        [HttpPost]
+        public async Task<ActionResult<ApplicationUserViewModel>> PostApplicationUser(ApplicationUserViewModel model)
+        {
+            if (model == null)
+            {
+                return BadRequest("User data is required");
+            }
+
+            if (string.IsNullOrWhiteSpace(model.UserName))
+            {
+                return BadRequest("Username is required");
+            }
+
+            if (model.Roles == null || !model.Roles.Any())
+            {
+                return BadRequest("At least one role is required");
+            }
+
+            if (await _context.ApplicationUsers.AnyAsync(u => u.UserName == model.UserName))
+            {
+                return BadRequest("Username already exists");
+            }
+
+            var user = _mapper.Map<ApplicationUser>(model);
+            user.CreatedDate = DateTime.UtcNow;
+            user.UpdatedDate = DateTime.UtcNow;
+
+            var result = await _userManager.CreateAsync(user, "mypassword");
+            if (!result.Succeeded)
+            {
+                return BadRequest(result.Errors);
+            }
+
+            await _userManager.AddToRolesAsync(user, model.Roles);
+
+            var vm = _mapper.Map<ApplicationUserViewModel>(user);
+            vm.Roles = model.Roles;
+            return CreatedAtAction(nameof(GetApplicationUser), new { id = user.Id }, vm);
         }
 
         private bool ApplicationUserExists(int id)


### PR DESCRIPTION
## Summary
- add server endpoints for listing, creating and updating users with role validation
- introduce admin user management page with Syncfusion grid and MudBlazor edit dialog
- update navigation to include Manage Users link
- refactor user edit dialog to inherit from BlazorBase instead of a partial class

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899055b656c832ab0833cb3db22e829