### PR TITLE
Activate Google Ads loading upon consent

### DIFF
--- a/JwtIdentity.Client/Layout/MainLayout.razor
+++ b/JwtIdentity.Client/Layout/MainLayout.razor
@@ -165,7 +165,7 @@
             bool consentGiven = await JSRuntime.InvokeAsync<bool>("userHasThirdPartyConsent");
             if (consentGiven)
             {
-            //    await JSRuntime.InvokeVoidAsync("loadGoogleAds");
+                await JSRuntime.InvokeVoidAsync("loadGoogleAds");
             }
         }
         catch (Exception ex)
@@ -224,7 +224,7 @@
         await JSRuntime.InvokeVoidAsync("acceptAllCookies");
         
         // Load Google Ads once consent is given
-      //  await JSRuntime.InvokeVoidAsync("loadGoogleAds");
+        await JSRuntime.InvokeVoidAsync("loadGoogleAds");
         
         StateHasChanged();
     }

--- a/JwtIdentity/wwwroot/js/site.js
+++ b/JwtIdentity/wwwroot/js/site.js
@@ -80,9 +80,9 @@ function acceptAllCookies(successCallback) {
                 successCallback();
             }
             // Load third-party services like Google Ads
-            //if (typeof loadGoogleAds === 'function') {
-            //    loadGoogleAds();
-            //}
+            if (typeof loadGoogleAds === 'function') {
+                loadGoogleAds();
+            }
         });
 }
 


### PR DESCRIPTION
Removed commented-out code in MainLayout.razor to ensure Google Ads are loaded directly after user consent is given. Updated site.js to actively call loadGoogleAds() if the function is defined, streamlining the process for loading third-party services.