### PR TITLE
Register SurveyHubClient with DI containers

### DIFF
--- a/JwtIdentity.Client/Program.cs
+++ b/JwtIdentity.Client/Program.cs
@@ -13,7 +13,7 @@ builder.Configuration
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
   builder.Services.AddScoped<IApiService, ApiService>();
-builder.Services.AddSingleton<SurveyHubClient>();
+builder.Services.AddScoped<SurveyHubClient>();
 
   var syncfusionLicense = builder.Configuration["Syncfusion:LicenseKey"];
   if (!string.IsNullOrWhiteSpace(syncfusionLicense))

--- a/JwtIdentity/Program.cs
+++ b/JwtIdentity/Program.cs
@@ -139,6 +139,7 @@ builder.Services.AddScoped<CustomAuthStateProvider>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IUtility, JwtIdentity.Client.Helpers.Utility>();
 builder.Services.AddScoped<IWordPressBlogService, WordPressBlogService>();
+builder.Services.AddScoped<SurveyHubClient>();
 builder.Services.AddTransient<CustomAuthorizationMessageHandler>();
 builder.Services.AddMudServices(config =>
 {


### PR DESCRIPTION
## Summary
- Register SurveyHubClient as a scoped service in both Blazor WebAssembly and server hosts
- Ensure real-time survey components can resolve SurveyHubClient during prerendering

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689a918ee2dc832abf9c1ab686de399d