### PR TITLE
Fix duplicate tracking when removing choice options

### DIFF
--- a/JwtIdentity/Controllers/SurveyController.cs
+++ b/JwtIdentity/Controllers/SurveyController.cs
@@ -287,7 +287,10 @@ namespace JwtIdentity.Controllers
                                     _ = _context.Questions.Update(existingRatingQuestion);
                                     break;
                                 case QuestionType.MultipleChoice:
-                                    var existingMCQuestion = await _context.Questions.OfType<MultipleChoiceQuestion>().AsNoTracking().Include(x => x.Options).FirstOrDefaultAsync(q => q.Id == passedInQuestion.Id);
+                                    var existingMCQuestion = await _context.Questions
+                                        .OfType<MultipleChoiceQuestion>()
+                                        .Include(x => x.Options)
+                                        .FirstOrDefaultAsync(q => q.Id == passedInQuestion.Id);
 
                                     if (existingMCQuestion != null && (existingMCQuestion.Text != passedInQuestion.Text
                                             || passedInQuestion.QuestionNumber != existingMCQuestion.QuestionNumber || existingMCQuestion.IsRequired != passedInQuestion.IsRequired))
@@ -343,7 +346,10 @@ namespace JwtIdentity.Controllers
                                     break;
 
                                 case QuestionType.SelectAllThatApply:
-                                    var existingSAQuestion = await _context.Questions.OfType<SelectAllThatApplyQuestion>().AsNoTracking().Include(x => x.Options).FirstOrDefaultAsync(q => q.Id == passedInQuestion.Id);
+                                    var existingSAQuestion = await _context.Questions
+                                        .OfType<SelectAllThatApplyQuestion>()
+                                        .Include(x => x.Options)
+                                        .FirstOrDefaultAsync(q => q.Id == passedInQuestion.Id);
 
                                     if (existingSAQuestion != null && (existingSAQuestion.Text != passedInQuestion.Text
                                             || passedInQuestion.QuestionNumber != existingSAQuestion.QuestionNumber || existingSAQuestion.IsRequired != passedInQuestion.IsRequired))


### PR DESCRIPTION
## Summary
- prevent EF duplicate tracking errors when removing choice options

## Testing
- `dotnet test JwtIdentity.Tests/JwtIdentity.Tests.csproj --filter PostSurvey_RemovedChoiceOption_DeletesOption`


------
https://chatgpt.com/codex/tasks/task_e_68a1fe388900832a8e27a547d38e1fd3