### PR TITLE
Improve SEO meta tags and accessibility

### DIFF
--- a/JwtIdentity.Client/Layout/MainLayout.razor
+++ b/JwtIdentity.Client/Layout/MainLayout.razor
@@ -32,7 +32,7 @@
         <div class="app-footer">
             <MudText Class="mx-auto footer-text" Typo="Typo.inherit">
                 <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2" AlignItems="AlignItems.Center" Class="justify-center">
-                    <MudImage Class="d-none d-md-block" Src="images/sectigo_trust_seal_sm_82x32.png" />
+                    <MudImage Class="d-none d-md-block" Src="images/sectigo_trust_seal_sm_82x32.png" Alt="Sectigo Trust Seal" />
                     <span>© @DateTime.Now.Year @Utility.Domain - All Rights Reserved</span>
                     <span class="d-none d-md-block">|</span>
                     

--- a/JwtIdentity.Client/Pages/Auth/Login.razor
+++ b/JwtIdentity.Client/Pages/Auth/Login.razor
@@ -6,7 +6,11 @@
 
 <PageTitle>Survey Shark - Login</PageTitle>
 
-<h3>Login</h3>
+<HeadContent>
+    <meta name="description" content="Log in to your Survey Shark account to manage surveys and view responses." />
+</HeadContent>
+
+<MudText Typo="Typo.h1" Class="mb-4">Login</MudText>
 
 <EditForm Model="applicationUserViewModel" OnValidSubmit="HandleLogin" FormName="LoginForm">
     <DataAnnotationsValidator />

--- a/JwtIdentity.Client/Pages/Auth/Register.razor
+++ b/JwtIdentity.Client/Pages/Auth/Register.razor
@@ -8,6 +8,11 @@
 
 <PageTitle>Survey Shark - Registration</PageTitle>
 
+<HeadContent>
+    <meta name="description" content="Create your Survey Shark account to start building and sharing surveys." />
+</HeadContent>
+<MudText Typo="Typo.h1" Class="mb-4">Register</MudText>
+
 <EditForm Model="registerModel" OnValidSubmit="HandleRegister">
     <MudTextField @bind-Value="@registerModel.Email" Label="Email" InputType="InputType.Email" />
     <MudTextField @bind-Value="@registerModel.Password" Label="Password" InputType="InputType.Password" />

--- a/JwtIdentity.Client/Pages/Blogs.razor
+++ b/JwtIdentity.Client/Pages/Blogs.razor
@@ -6,6 +6,12 @@
 
 <PageTitle>Blog Posts - Survey Shark</PageTitle>
 
+<HeadContent>
+    <meta name="description" content="Read the latest news and articles from the Survey Shark blog." />
+</HeadContent>
+
+<MudText Typo="Typo.h1" Class="mb-4">Blog Posts</MudText>
+
 @if (posts == null)
 {
     <p><em>Loading posts...</em></p>

--- a/JwtIdentity.Client/Pages/Documentation/Documentation.razor
+++ b/JwtIdentity.Client/Pages/Documentation/Documentation.razor
@@ -5,9 +5,12 @@
 @rendermode InteractiveWebAssembly
 
 <PageTitle>Survey Shark - Documentation</PageTitle>
+<HeadContent>
+    <meta name="description" content="Learn how to use Survey Shark with guides and tutorials in our documentation." />
+</HeadContent>
 
 <MudContainer MaxWidth="MaxWidth.Large" Class="pt-4">
-    <MudText Typo="Typo.h3" Class="mb-4">Documentation</MudText>
+    <MudText Typo="Typo.h1" Class="mb-4">Documentation</MudText>
     
     <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
         <MudTabPanel Text="Getting Started">

--- a/JwtIdentity.Client/Pages/LearnMore/LearnMoreAI.razor
+++ b/JwtIdentity.Client/Pages/LearnMore/LearnMoreAI.razor
@@ -4,9 +4,12 @@
 @rendermode InteractiveWebAssembly
 
 <PageTitle>AI-Powered Question Generation - Survey Shark</PageTitle>
+<HeadContent>
+    <meta name="description" content="Discover how Survey Shark uses AI to instantly generate survey questions." />
+</HeadContent>
 <MudContainer Class="mt-6 mb-8">
     <MudPaper Elevation="2" Class="pa-6 text-center mb-8">
-        <MudText Typo="Typo.h3" Class="mb-2">AI-Powered Question Generation</MudText>
+        <MudText Typo="Typo.h1" Class="mb-2">AI-Powered Question Generation</MudText>
         <MudText Typo="Typo.body1" Class="mb-4">
             <b>What should you write in the AI Instructions box?</b><br />
             <span style="font-size:1.1rem;">Instead of typing the actual survey questions, simply describe the kind of questions you want the AI to generate. For example, explain your survey's purpose, your target audience, and any specific question types or topics you want included. The AI will then create a set of relevant questions for you, which you can edit as needed.</span>
@@ -79,7 +82,7 @@
                 "Was your issue resolved on the first visit? (Yes/No)",
                 "What could we do to improve your experience? (Free text)"
             },
-            Explanation = "This example shows how to describe your business and the type of feedback you want. The AI generates a balanced set of questions, including ratings, yes/no, and an open-ended prompt. You don't need to write the questions yourself—just describe your goals."
+            Explanation = "This example shows how to describe your business and the type of feedback you want. The AI generates a balanced set of questions, including ratings, yes/no, and an open-ended prompt. You don't need to write the questions yourselfâ€”just describe your goals."
         },
         new AIExample {
             Title = "Employee Engagement Survey",

--- a/JwtIdentity.Client/Pages/LearnMore/LearnMoreAnalytics.razor
+++ b/JwtIdentity.Client/Pages/LearnMore/LearnMoreAnalytics.razor
@@ -4,9 +4,12 @@
 @rendermode InteractiveWebAssembly
 
 <PageTitle>Real-Time Analytics - Survey Shark</PageTitle>
+<HeadContent>
+    <meta name="description" content="See how Survey Shark provides real-time analytics for your survey responses." />
+</HeadContent>
 <MudContainer Class="mt-6 mb-8">
     <MudPaper Elevation="2" Class="pa-6 text-center">
-        <MudText Typo="Typo.h3" Class="mb-2">Real-Time Analytics</MudText>
+        <MudText Typo="Typo.h1" Class="mb-2">Real-Time Analytics</MudText>
         <MudText Typo="Typo.body1" Class="mb-4">
             Instantly visualize your survey results as they come in. Survey Shark provides real-time charts and insights, helping you make data-driven decisions faster than ever.
         </MudText>

--- a/JwtIdentity.Client/Pages/LearnMore/LearnMoreMobile.razor
+++ b/JwtIdentity.Client/Pages/LearnMore/LearnMoreMobile.razor
@@ -4,11 +4,14 @@
 @rendermode InteractiveWebAssembly
 
 <PageTitle>Mobile-Ready & Responsive - Survey Shark</PageTitle>
+<HeadContent>
+    <meta name="description" content="Explore Survey Shark's mobile-ready and responsive survey experience." />
+</HeadContent>
 <MudContainer Class="mt-6 mb-8">
     <MudPaper Elevation="2" Class="pa-6 text-center">
-        <MudText Typo="Typo.h3" Class="mb-2">Mobile-Ready & Responsive</MudText>
+        <MudText Typo="Typo.h1" Class="mb-2">Mobile-Ready & Responsive</MudText>
         <MudText Typo="Typo.body1" Class="mb-4">
-            Every survey you create with Survey Shark is optimized for all devices. Enjoy a seamless experience on phones, tablets, and desktops—no extra work required.
+            Every survey you create with Survey Shark is optimized for all devices. Enjoy a seamless experience on phones, tablets, and desktopsâ€”no extra work required.
         </MudText>
         <MudList T="string" Dense="true" Class="mb-4">
             <MudListItem Icon="@Icons.Material.Filled.PhoneIphone" IconColor="Color.Success">

--- a/JwtIdentity.Client/Pages/Legal/CookiePolicy.razor
+++ b/JwtIdentity.Client/Pages/Legal/CookiePolicy.razor
@@ -5,9 +5,12 @@
 @rendermode InteractiveWebAssembly
 
 <PageTitle>Survey Shark - Cookie Policy</PageTitle>
+<HeadContent>
+    <meta name="description" content="Learn how Survey Shark uses cookies to enhance and secure your experience." />
+</HeadContent>
 
 <MudContainer MaxWidth="MaxWidth.Large" Class="pt-4 pb-8">
-    <MudText Typo="Typo.h3" Class="mb-4">Survey Shark Cookie Policy</MudText>
+    <MudText Typo="Typo.h1" Class="mb-4">Survey Shark Cookie Policy</MudText>
     
     <MudPaper Elevation="3" Class="pa-4 mb-4">
         <MudText Typo="Typo.h5" Class="mb-3">Last Updated: April 22, 2025</MudText>

--- a/JwtIdentity.Client/Pages/Legal/PrivacyPolicy.razor
+++ b/JwtIdentity.Client/Pages/Legal/PrivacyPolicy.razor
@@ -5,9 +5,12 @@
 @rendermode InteractiveWebAssembly
 
 <PageTitle>Survey Shark - Privacy Policy</PageTitle>
+<HeadContent>
+    <meta name="description" content="Understand how Survey Shark collects, uses, and protects your information." />
+</HeadContent>
 
 <MudContainer MaxWidth="MaxWidth.Large" Class="pt-4 pb-8">
-    <MudText Typo="Typo.h3" Class="mb-4">Privacy Policy</MudText>
+    <MudText Typo="Typo.h1" Class="mb-4">Privacy Policy</MudText>
     
     <MudPaper Elevation="3" Class="pa-4 mb-4">
         <MudText Typo="Typo.h5" Class="mb-3">Last Updated: 4/21/2025</MudText>

--- a/JwtIdentity.Client/Pages/Legal/TermsOfService.razor
+++ b/JwtIdentity.Client/Pages/Legal/TermsOfService.razor
@@ -6,9 +6,12 @@
 @rendermode InteractiveWebAssembly
 
 <PageTitle>Survey Shark - Terms of Service</PageTitle>
+<HeadContent>
+    <meta name="description" content="Review the Survey Shark Terms of Service governing use of our platform." />
+</HeadContent>
 
 <MudContainer MaxWidth="MaxWidth.Large" Class="pt-4 pb-8">
-    <MudText Typo="Typo.h3" Class="mb-4">Terms of Service</MudText>
+    <MudText Typo="Typo.h1" Class="mb-4">Terms of Service</MudText>
     <MudPaper Elevation="3" Class="pa-4 mb-4">
         <MudText Typo="Typo.body1" Class="mb-4">
             Welcome to Survey Shark! These Terms of Service ("Terms") govern your use of our website (surveyshark.site or www.surveyshark.site or known as Survey Shark), tools, and services (collectively referred to as "Services"). By accessing or using our Services, you agree to comply with and be bound by these Terms.

--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
@@ -2,7 +2,7 @@
 
 <MudAppBar Elevation="4" Fixed="true">
     <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="ToggleDrawer" />
-    <MudImage Src="images/logo_200_60.png" />
+    <MudImage Src="images/logo_200_60.png" Alt="Survey Shark logo" />
     <MudSpacer />
 
     <div class="d-none d-md-flex">
@@ -129,6 +129,6 @@
         <MudNavLink Href="/privacy-policy" Underline="Underline.None" Typo="Typo.inherit">Privacy Policy</MudNavLink>        
         <MudNavLink Href="/cookie-policy" Underline="Underline.None" Typo="Typo.inherit">Cookie Policy</MudNavLink>        
         <MudNavLink Href="/terms-of-service" Underline="Underline.None" Typo="Typo.inherit">Terms of Service</MudNavLink>
-        <MudImage Src="images/sectigo_trust_seal_sm_82x32.png" />
+        <MudImage Src="images/sectigo_trust_seal_sm_82x32.png" Alt="Sectigo Trust Seal" />
     </MudNavMenu>
 </MudDrawer>


### PR DESCRIPTION
## Summary
- add meta descriptions and h1 headers to public pages
- include alt text on navigation and footer images

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b8d093f0832abb6c47113eb14470