### PR TITLE
feat: show survey creator for admins

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/SurveysICreated.razor
+++ b/JwtIdentity.Client/Pages/Survey/SurveysICreated.razor
@@ -154,6 +154,10 @@
         </GridColumn>
         <GridColumn Field="Title" HeaderText="Title" Width="200" />
         <GridColumn Field="Description" HeaderText="Description" Width="400" />
+        @if (IsAdmin)
+        {
+            <GridColumn Field="CreatedBy.UserName" HeaderText="Created By" Width="160" AllowSorting="true" AllowFiltering="true" />
+        }
         <GridColumn Field="NumberOfResponses" HeaderText="Responses" Width="120" TextAlign="TextAlign.Center" />
         <GridColumn Field="CreatedDate" HeaderText="Created Date" Width="160" Type=" ColumnType.Date" Format="d" />
     </GridColumns>

--- a/JwtIdentity.Client/Pages/Survey/SurveysICreated.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/SurveysICreated.razor.cs
@@ -1,4 +1,6 @@
-﻿namespace JwtIdentity.Client.Pages.Survey
+﻿using JwtIdentity.Client.Services;
+
+namespace JwtIdentity.Client.Pages.Survey
 {
     public class SurveysICreatedModel : BlazorBase, IBrowserViewportObserver, IAsyncDisposable
     {
@@ -6,6 +8,8 @@
         protected IBrowserViewportService BrowserViewportService { get; set; }
 
         public List<SurveyViewModel> UserSurveys { get; set; } = new();
+
+        protected bool IsAdmin => ((CustomAuthStateProvider)AuthStateProvider).CurrentUser?.Roles.Contains("Admin") ?? false;
 
         protected int FrozenColumns { get; set; }
 

--- a/JwtIdentity.Tests/ControllerTests/SurveyControllerTests.cs
+++ b/JwtIdentity.Tests/ControllerTests/SurveyControllerTests.cs
@@ -158,6 +158,17 @@ namespace JwtIdentity.Tests.ControllerTests
         }
 
         [Test]
+        public async Task GetSurveysICreated_Admin_ReturnsAllSurveys()
+        {
+            HttpContext.User = CreateClaimsPrincipal(1, "admin", new[] { "Admin" });
+            var result = await _controller.GetSurveysICreated();
+            Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+            var ok = result.Result as OkObjectResult;
+            var surveys = ok!.Value as IEnumerable<SurveyViewModel>;
+            Assert.That(surveys!.Count(), Is.EqualTo(_mockSurveys.Count));
+        }
+
+        [Test]
         public async Task GetSurveysIAnswered_ReturnsSurveysUserAnswered()
         {
             // This test assumes the user has answered at least one question in survey 1


### PR DESCRIPTION
## Summary
- return all surveys for admin users and expose creator info
- add admin-only "Created By" column on Surveys I Created page
- cover admin retrieval in controller tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a8ce50a910832aa95ef2fd7bad2622