### PR TITLE
Show friendly login error

### DIFF
--- a/JwtIdentity.Client/Services/ApiService.cs
+++ b/JwtIdentity.Client/Services/ApiService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Json;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -133,6 +134,12 @@ namespace JwtIdentity.Client.Services
             if (!response.IsSuccessStatusCode)
             {
                 var error = await response.Content.ReadAsStringAsync();
+
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    _ = Snackbar.Add("Invalid username or password", Severity.Error);
+                    return default;
+                }
 
                 if (string.IsNullOrEmpty(error))
                 {


### PR DESCRIPTION
## Summary
- Replace raw problem details in the snackbar with a readable message when login fails with invalid credentials

## Testing
- `dotnet test JwtIdentity.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a8d68ae420832ab4d3a129ce152006