### PR TITLE
Improve demo popover placement

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/CreateSurvey.razor
+++ b/JwtIdentity.Client/Pages/Survey/CreateSurvey.razor
@@ -41,35 +41,35 @@
     </div>
 </EditForm>
 
-<MudPopover Open="@ShowDemoStep(0)" AnchorReference="AnchorReference.Element" AnchorEl="@TitleRef">
+<MudPopover Open="@ShowDemoStep(0)" AnchorReference="AnchorReference.Element" AnchorEl="@TitleRef" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" OffsetX="5" OffsetY="5">
     <MudPaper Class="pa-4">
         <MudText Typo="Typo.body2">Let's start with a title for your survey. Click Next to use our suggestion.</MudText>
         <MudButton Class="mt-2" OnClick="NextDemoStep">Next</MudButton>
     </MudPaper>
 </MudPopover>
 
-<MudPopover Open="@ShowDemoStep(1)" AnchorReference="AnchorReference.Element" AnchorEl="@DescriptionRef">
+<MudPopover Open="@ShowDemoStep(1)" AnchorReference="AnchorReference.Element" AnchorEl="@DescriptionRef" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" OffsetX="5" OffsetY="5">
     <MudPaper Class="pa-4">
         <MudText Typo="Typo.body2">Great! Now add a description. This helps guide the AI engine. Click Next to fill it in.</MudText>
         <MudButton Class="mt-2" OnClick="NextDemoStep">Next</MudButton>
     </MudPaper>
 </MudPopover>
 
-<MudPopover Open="@ShowDemoStep(2)" AnchorReference="AnchorReference.Element" AnchorEl="@AiRef">
+<MudPopover Open="@ShowDemoStep(2)" AnchorReference="AnchorReference.Element" AnchorEl="@AiRef" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" OffsetX="5" OffsetY="5">
     <MudPaper Class="pa-4">
         <MudText Typo="Typo.body2">Provide instructions for the AI-generated questions. Click Next to use an example.</MudText>
         <MudButton Class="mt-2" OnClick="NextDemoStep">Next</MudButton>
     </MudPaper>
 </MudPopover>
 
-<MudPopover Open="@ShowDemoStep(3)" AnchorReference="AnchorReference.Element" AnchorEl="@DescriptionRef">
+<MudPopover Open="@ShowDemoStep(3)" AnchorReference="AnchorReference.Element" AnchorEl="@DescriptionRef" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" OffsetX="5" OffsetY="5">
     <MudPaper Class="pa-4">
         <MudText Typo="Typo.body2">Only the title and description are required to create a survey. AI instructions are optional.</MudText>
         <MudButton Class="mt-2" OnClick="NextDemoStep">Next</MudButton>
     </MudPaper>
 </MudPopover>
 
-<MudPopover Open="@ShowDemoStep(4)" AnchorReference="AnchorReference.Element" AnchorEl="@CreateButtonRef">
+<MudPopover Open="@ShowDemoStep(4)" AnchorReference="AnchorReference.Element" AnchorEl="@CreateButtonRef" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" OffsetX="5" OffsetY="5">
     <MudPaper Class="pa-4">
         <MudText Typo="Typo.body2">All set! Click the Create button to generate your survey.</MudText>
         <MudButton Class="mt-2" OnClick="NextDemoStep">Close</MudButton>

--- a/JwtIdentity.Client/Pages/Survey/CreateSurvey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/CreateSurvey.razor.cs
@@ -13,6 +13,9 @@
         protected ElementReference AiRef;
         protected ElementReference CreateButtonRef;
 
+        protected Origin AnchorOrigin { get; set; } = Origin.BottomRight;
+        protected Origin TransformOrigin { get; set; } = Origin.TopLeft;
+
         protected override async Task OnInitializedAsync()
         {
             var authState = await AuthStateProvider.GetAuthenticationStateAsync();
@@ -20,6 +23,20 @@
         }
 
         protected bool ShowDemoStep(int step) => IsDemoUser && DemoStep == step;
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                var isMobile = await JSRuntime.InvokeAsync<bool>("isMobile");
+                if (isMobile)
+                {
+                    AnchorOrigin = Origin.BottomCenter;
+                    TransformOrigin = Origin.TopCenter;
+                }
+                StateHasChanged();
+            }
+        }
 
         protected void NextDemoStep()
         {

--- a/JwtIdentity/wwwroot/js/site.js
+++ b/JwtIdentity/wwwroot/js/site.js
@@ -33,6 +33,11 @@ function registerCaptchaCallback(dotnetHelper) {
     window.dotnetHelper = dotnetHelper;
 }
 
+// Returns true if the screen width is typical of a mobile device
+function isMobile() {
+    return window.innerWidth <= 768;
+}
+
 function loadGoogleAds() {
     if (document.getElementById('google-ads-script')) {
         return; // Avoid loading multiple times


### PR DESCRIPTION
## Summary
- adjust demo popovers to anchor below inputs and on the right, using JS to detect mobile layout
- add mobile detection helper to site.js

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a9f0634480832a96c208a13a2bc11a