### PR TITLE
Ensure demo step scroll completes before dialog

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/EditSurvey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/EditSurvey.razor.cs
@@ -149,6 +149,9 @@ namespace JwtIdentity.Client.Pages.Survey
             if (!string.IsNullOrEmpty(id))
             {
                 await JSRuntime.InvokeVoidAsync("scrollToElement", id);
+
+                // Ensure any demo popover tied to the element renders after the scroll
+                StateHasChanged();
             }
         }
 


### PR DESCRIPTION
## Summary
- Wait for scroll animations in `scrollToElement` before resolving
- Trigger re-render after scrolling so demo popovers display after navigation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa252bdb54832a904fd89f8ec30da1