### PR TITLE
Fix demo highlight animation for selected survey question

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -517,6 +517,10 @@ td.e-summarycell.e-templatecell.e-leftalign {
 .alternate-background-red {
     animation: alternate-background-red 0.5s infinite alternate;
 }
+.mud-list-item.alternate-background-red,
+.mud-selected-item.alternate-background-red {
+    animation: alternate-background-red 0.5s infinite alternate !important;
+}
 @keyframes alternate-background-red {
     from { background-color: inherit; }
     to { background-color: red; }


### PR DESCRIPTION
## Summary
- ensure demo question highlight animation persists when item is selected
- target list item itself to override MudBlazor animation reset

## Testing
- `~/.dotnet/dotnet test --no-restore -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68aa77c9e8a8832ab10cb07213bbe38f