### PR TITLE
Fix MudBlazor asset linking and debug animation style

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/EditSurvey.razor
+++ b/JwtIdentity.Client/Pages/Survey/EditSurvey.razor
@@ -50,7 +50,7 @@
                                             css += " alternate-background-red";
                                         }
                                     }
-                                        <MudListItem Class=@css Text="@($"{question.QuestionNumber}. {question.Text}")" Value="@question" />
+                                        <MudListItem Class=@css Text="@($"{question.QuestionNumber}. {question.Text}")" Value="@question" Style="animation: alternate-background-red 0.5s infinite alternate; background-color: red !important;" />
 
                                     @if (question.IsRequired)
                                     {

--- a/JwtIdentity/Components/App.razor
+++ b/JwtIdentity/Components/App.razor
@@ -17,7 +17,7 @@
     <base href="/" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+    <link href="@Assets["_content/MudBlazor/MudBlazor.min.css"]" rel="stylesheet" />
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" class="theme" />
 
     
@@ -44,7 +44,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <script src="_framework/blazor.web.js"></script>
-    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="@Assets["_content/MudBlazor/MudBlazor.min.js"]"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- load MudBlazor assets via the `@Assets` helper
- add inline animation style to survey question items to isolate cascade conflicts

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8fb983dc832a8c030b75e63dde49