### PR TITLE
feat: add public client for unauthenticated API calls

### DIFF
--- a/JwtIdentity.Client/Layout/MainLayout.razor
+++ b/JwtIdentity.Client/Layout/MainLayout.razor
@@ -124,7 +124,7 @@
 
         try
         {
-            AppSettings = await ApiService.GetAsync<AppSettings>("/api/appsettings");
+            AppSettings = await ApiService.GetPublicAsync<AppSettings>("/api/appsettings");
 
             // reference app.js in the wwwroot folder
             module = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./js/app.js");

--- a/JwtIdentity.Client/Pages/Auth/PleaseCheckYourEmail.razor.cs
+++ b/JwtIdentity.Client/Pages/Auth/PleaseCheckYourEmail.razor.cs
@@ -10,7 +10,7 @@
 
         protected override async Task OnInitializedAsync()
         {
-            AppSettings = await ApiService.GetAsync<AppSettings>("/api/appsettings");
+            AppSettings = await ApiService.GetPublicAsync<AppSettings>("/api/appsettings");
         }
     }
 }

--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
@@ -17,7 +17,7 @@
 
         protected override async Task OnInitializedAsync()
         {
-            AppSettings = await ApiService.GetAsync<AppSettings>("/api/appsettings");
+            AppSettings = await ApiService.GetPublicAsync<AppSettings>("/api/appsettings");
         }
 
         protected override void OnInitialized()

--- a/JwtIdentity.Client/Program.cs
+++ b/JwtIdentity.Client/Program.cs
@@ -62,7 +62,10 @@ builder.Services.AddHttpClient("AuthorizedClient", client =>
 .AddHttpMessageHandler<CustomAuthorizationMessageHandler>();
 
 
-// Register a named HttpClient called "NoAuthClient" for unauthenticated requests
-builder.Services.AddHttpClient("NoAuthClient");
+// Register a named HttpClient called "PublicClient" for unauthenticated requests
+builder.Services.AddHttpClient("PublicClient", client =>
+{
+    client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
+});
 
 await builder.Build().RunAsync();

--- a/JwtIdentity.Client/Services/IApiService.cs
+++ b/JwtIdentity.Client/Services/IApiService.cs
@@ -3,6 +3,7 @@
     public interface IApiService
     {
         Task<T> GetAsync<T>(string endpoint);
+        Task<T> GetPublicAsync<T>(string endpoint);
         Task<IEnumerable<T>> GetAllAsync<T>(string endpoint);
         Task<T> PostAsync<T>(string endpoint, T viewModel);
         Task<R> PostAsync<T, R>(string endpoint, T viewModel);

--- a/JwtIdentity.Client/Services/WordPressBlogService.cs
+++ b/JwtIdentity.Client/Services/WordPressBlogService.cs
@@ -23,7 +23,7 @@ namespace JwtIdentity.Services
         {
             try
             {
-                AppSettings = await _apiService.GetAsync<AppSettings>("/api/appsettings");
+                AppSettings = await _apiService.GetPublicAsync<AppSettings>("/api/appsettings");
 
                 // Read the WordPress site domain from configuration (appsettings.json)
                 _siteDomain = AppSettings.WordPress.SiteDomain ?? throw new Exception("WordPress site domain not configured");
@@ -31,8 +31,8 @@ namespace JwtIdentity.Services
 
                 _getUrl = _getUrl.Replace("{Wordpress:SiteDomain}", _siteDomain);
 
-                // Use the NoAuthClient for WordPress API requests
-                var httpClient = _httpClientFactory.CreateClient("NoAuthClient");
+                // Use the PublicClient for WordPress API requests
+                var httpClient = _httpClientFactory.CreateClient("PublicClient");
 
                 var response = await httpClient.GetAsync(_getUrl);
                 _ = response.EnsureSuccessStatusCode();
@@ -61,15 +61,15 @@ namespace JwtIdentity.Services
         {
             try
             {
-                AppSettings = await _apiService.GetAsync<AppSettings>("/api/appsettings");
+                AppSettings = await _apiService.GetPublicAsync<AppSettings>("/api/appsettings");
                 _siteDomain = AppSettings.WordPress.SiteDomain ?? throw new Exception("WordPress site domain not configured");
 
                 _getUrl = AppSettings.WordPress.SinglePostUrl ?? throw new Exception("WordPress Get Url not configured");
                 _getUrl = _getUrl.Replace("{Wordpress:SiteDomain}", _siteDomain);
                 _getUrl = _getUrl.Replace("{postSlug}", postSlug);
 
-                // Use the NoAuthClient for WordPress API requests
-                var httpClient = _httpClientFactory.CreateClient("NoAuthClient");
+                // Use the PublicClient for WordPress API requests
+                var httpClient = _httpClientFactory.CreateClient("PublicClient");
 
                 var response = await httpClient.GetAsync(_getUrl);
                 _ = response.EnsureSuccessStatusCode();

--- a/JwtIdentity/Program.cs
+++ b/JwtIdentity/Program.cs
@@ -150,7 +150,7 @@ builder.Services.AddHttpClient("AuthorizedClient", (sp, client) =>
     var request = accessor.HttpContext?.Request;
     client.BaseAddress = new Uri($"{request?.Scheme}://{request?.Host}");
 }).AddHttpMessageHandler<CustomAuthorizationMessageHandler>();
-builder.Services.AddHttpClient("NoAuthClient", (sp, client) =>
+builder.Services.AddHttpClient("PublicClient", (sp, client) =>
 {
     var accessor = sp.GetRequiredService<IHttpContextAccessor>();
     var request = accessor.HttpContext?.Request;


### PR DESCRIPTION
## Summary
- add PublicClient for anonymous HTTP requests
- extend ApiService with GetPublicAsync and use in appsettings calls
- update WordPress blog service to use public client

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ae674bc100832a9d29958251a994f6