### PR TITLE
Refine appsettings retrieval and logging

### DIFF
--- a/JwtIdentity.Client/Layout/MainLayout.razor
+++ b/JwtIdentity.Client/Layout/MainLayout.razor
@@ -19,7 +19,7 @@
 <CascadingValue Value="_theme" Name="Theme">
     <div class="app-container">
         <!-- Fixed height header -->
-        <MyNavMenu @bind-DarkTheme="@_isDarkMode" @bind-DarkTheme:after="HandleThemeChanged" />        
+        <MyNavMenu AppSettings="@AppSettings" @bind-DarkTheme="@_isDarkMode" @bind-DarkTheme:after="HandleThemeChanged" />
         
         <!-- Flexible main content with scrolling -->
         <div class="main-content">

--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
@@ -14,9 +14,11 @@ namespace JwtIdentity.Client.Pages.Navigation
 
         [Parameter]
         public EventCallback<bool> DarkThemeChanged { get; set; }
-        protected bool _drawerOpen { get; set; } = false;
 
-        protected AppSettings AppSettings { get; set; } = new();
+        [Parameter]
+        public AppSettings AppSettings { get; set; } = new();
+
+        protected bool _drawerOpen { get; set; } = false;
 
         protected bool IsAuthenticated { get; private set; }
         protected bool IsAdmin { get; private set; }
@@ -26,7 +28,6 @@ namespace JwtIdentity.Client.Pages.Navigation
 
         protected override async Task OnInitializedAsync()
         {
-            AppSettings = await ApiService.GetPublicAsync<AppSettings>("/api/appsettings");
             await SetAuthFlagsAsync();
         }
 

--- a/JwtIdentity.Client/Program.cs
+++ b/JwtIdentity.Client/Program.cs
@@ -3,6 +3,7 @@ using JwtIdentity.Client.Helpers;
 using JwtIdentity.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.Logging;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<HeadOutlet>("head::after");
@@ -67,5 +68,9 @@ builder.Services.AddHttpClient("PublicClient", client =>
 {
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
 });
+
+builder.Logging.SetMinimumLevel(LogLevel.Warning);
+builder.Logging.AddFilter("Microsoft.AspNetCore.Authorization", LogLevel.Warning);
+builder.Logging.AddFilter("System.Net.Http.HttpClient", LogLevel.Warning);
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
## Summary
- Pass AppSettings from MainLayout to MyNavMenu to avoid redundant API calls
- Suppress verbose HTTP and authorization logs in the client

## Testing
- `DOTNET_SDK_ROLL_FORWARD=major dotnet test` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7114cd70832a850a7d5241b10141