### PR TITLE
Restore animation highlights on EditSurvey page

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -517,6 +517,7 @@ td.e-summarycell.e-templatecell.e-leftalign {
 .alternate-background-red {
     --alternate-bg-color: inherit;
     animation: alternate-background-red 0.5s infinite alternate;
+    background-color: var(--alternate-bg-color);
 }
 .mud-list-item.alternate-background-red,
 .mud-selected-item.alternate-background-red,


### PR DESCRIPTION
## Summary
- restore blinking background animation for all demo elements on EditSurvey page

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c0a87d60832ab899757ad1465e7a