### PR TITLE
Use success border for demo highlights

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/EditSurvey.razor
+++ b/JwtIdentity.Client/Pages/Survey/EditSurvey.razor
@@ -24,7 +24,7 @@
             string panelCss = "";
             if (ShowDemoStep(0))
             {
-                panelCss = "alternate-background-red";
+                panelCss = "demo-success-border";
             }
 
             <MudExpansionPanel Id="QuestionsPanel" Expanded="@QuestionsPanelExpanded" Class=@panelCss ExpandedChanged="HandleQuestionsPanelExpanded">
@@ -48,7 +48,7 @@
                                         
                                         if ((ShowDemoStep(2) || ShowDemoStep(4) || ShowDemoStep(6)) && question.QuestionNumber == 1)
                                         {
-                                                css += " alternate-background-red";
+                                                css += " demo-success-border";
                                         }                                        
 
                                         <MudListItem Class="@css" Text="@($"{question.QuestionNumber}. {question.Text}")" Value="@question" />
@@ -100,7 +100,7 @@
                     <MudPaper Class="p-2">
                         <MudStack Spacing="1">
                         @{
-                            string QuestionTypeSelectCss = ShowDemoStep(5) ? "alternate-background-red" : "";                            
+                            string QuestionTypeSelectCss = ShowDemoStep(5) ? "demo-success-border" : "";
                         }
 
                         <MudSelect Id="QuestionTypeSelect" Label="Select the Question Type" Class="@QuestionTypeSelectCss"
@@ -123,7 +123,7 @@
                             </MudPopover>
 
                              <MudText Typo="Typo.h6" Class="mt-5">Create a @StringHelper.PascalCaseToWords(SelectedQuestionType) Question</MudText>
-                        <MudTextField Id="Text" Label="Question Text" @bind-Value="QuestionText" Variant="Variant.Filled" Lines="1" MaxLines="5" AutoGrow="true" Immediate="true" Counter="500" MaxLength="500" Class="@(ShowDemoStep(3) ? "alternate-background-red" : "")" />
+                        <MudTextField Id="Text" Label="Question Text" @bind-Value="QuestionText" Variant="Variant.Filled" Lines="1" MaxLines="5" AutoGrow="true" Immediate="true" Counter="500" MaxLength="500" Class="@(ShowDemoStep(3) ? "demo-success-border" : "")" />
                             <MudPopover Open="@ShowDemoStep(3)" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Fixed="true">
                                 <MudPaper Class="pa-4">
                                     <MudText Typo="Typo.body2" Style="white-space: pre-line">Scroll down to edit the question text.

--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -514,23 +514,13 @@ td.e-summarycell.e-templatecell.e-leftalign {
 }
 
 /* Alternating red/default background color every 0.5s */
-.alternate-background-red {
-    --alternate-bg-color: inherit;
-    animation: alternate-background-red 0.5s infinite alternate;
-    background-color: var(--alternate-bg-color);
+.demo-success-border {
+    box-shadow: 0 0 0 2px var(--mud-palette-success);
+    border-radius: 4px;
 }
-.mud-list-item.alternate-background-red,
-.mud-selected-item.alternate-background-red,
-.mud-primary-hover.alternate-background-red {
-    animation: alternate-background-red 0.5s infinite alternate !important;
-    background-color: var(--alternate-bg-color) !important;
-}
-@keyframes alternate-background-red {
-    from { --alternate-bg-color: inherit; }
-    to { --alternate-bg-color: red; }
-}
-
-/* Respect reduced motion preferences */
-@media (prefers-reduced-motion: reduce) {
-    .alternate-background-red { animation: none; }
+.mud-list-item.demo-success-border,
+.mud-selected-item.demo-success-border,
+.mud-primary-hover.demo-success-border {
+    box-shadow: 0 0 0 2px var(--mud-palette-success) !important;
+    border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- Replace flashing background demo style with `demo-success-border` class using MudBlazor success color
- Apply new border highlight on Edit Survey demo steps

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b3c9aa58dc832ab202f29937830765