### PR TITLE
Enable Chrome launch and hot reload in API script

### DIFF
--- a/API.ps1
+++ b/API.ps1
@@ -1,2 +1,9 @@
-﻿cd C:\Users\bgmsd\source\repos\JwtIdentity\JwtIdentity
-dotnet run watch JwtIdentity.csproj
+# Navigate to the server project directory relative to this script
+Set-Location "$PSScriptRoot/JwtIdentity"
+
+# Launch Google Chrome at the development URL
+Start-Process "chrome" "https://localhost:5001"
+
+# Start the API with hot reload enabled
+dotnet watch run --launch-profile https
+

--- a/JwtIdentity/Properties/launchSettings.json
+++ b/JwtIdentity/Properties/launchSettings.json
@@ -5,14 +5,14 @@
       "launchBrowser": true,
       "launchUrl": "https://localhost:5001",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_BROWSER": "chrome"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "dotnetRunMessages": true,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "applicationUrl": "https://localhost:5001",
       "hotReloadEnabled": true,
-      "hotReloadProfile": "aspnetcore"
+      "hotReloadProfile": "aspnetcore",
+      "browser": "chrome"
     },
     "Swagger": {
       "commandName": "Project",


### PR DESCRIPTION
## Summary
- ensure https profile launches Chrome
- add API.ps1 to start API with hot reload and open Chrome

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found; requested 9.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4da154e2c832ab847f5fac9a5f588