### PR TITLE
Add dynamic demo user creation and cleanup job

### DIFF
--- a/JwtIdentity.Client/Pages/Demo/DemoBorder.razor.cs
+++ b/JwtIdentity.Client/Pages/Demo/DemoBorder.razor.cs
@@ -25,7 +25,8 @@ namespace JwtIdentity.Client.Pages.Demo
         protected override async Task OnInitializedAsync()
         {
             var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-            IsDemoUser = authState.User.Identity?.Name == "DemoUser@surveyshark.site";
+            var userName = authState.User.Identity?.Name ?? string.Empty;
+            IsDemoUser = userName.StartsWith("DemoUser") && userName.EndsWith("@surveyshark.site");
         }
     }
 }

--- a/JwtIdentity.Client/Pages/Demo/DemoPopup.razor.cs
+++ b/JwtIdentity.Client/Pages/Demo/DemoPopup.razor.cs
@@ -27,7 +27,8 @@
         protected override async Task OnInitializedAsync()
         {
             var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-            IsDemoUser = authState.User.Identity?.Name == "DemoUser@surveyshark.site";
+            var userName = authState.User.Identity?.Name ?? string.Empty;
+            IsDemoUser = userName.StartsWith("DemoUser") && userName.EndsWith("@surveyshark.site");
         }
     }
 }

--- a/JwtIdentity.Client/Pages/Home.razor.cs
+++ b/JwtIdentity.Client/Pages/Home.razor.cs
@@ -9,11 +9,7 @@
             if (DemoLoading) return;
             DemoLoading = true;
 
-            Response<ApplicationUserViewModel> loginResponse = await AuthService.Login(new ApplicationUserViewModel()
-            {
-                UserName = "logmeindemouser",
-                Password = "123"
-            });
+            Response<ApplicationUserViewModel> loginResponse = await AuthService.StartDemo();
 
             if (loginResponse.Success)
             {

--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
@@ -50,7 +50,7 @@
             </MudMenu>
         }
         <div class="mx-1">
-            @if (IsAuthenticated)
+            @if (IsAuthenticated && !IsDemoUser)
             {
                 <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mx-2" Href="logout">Logout</MudButton>
             }
@@ -66,7 +66,7 @@
 <MudDrawer @bind-Open="_drawerOpen" Anchor="MudBlazor.Anchor.Left" Variant="DrawerVariant.Temporary" Elevation="1">
     <MudDrawerHeader>Menu</MudDrawerHeader>
     <MudNavMenu>
-        @if (IsAuthenticated)
+        @if (IsAuthenticated && !IsDemoUser)
         {
             <MudNavLink Href="logout">Logout</MudNavLink>
         }

--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
@@ -25,6 +25,7 @@ namespace JwtIdentity.Client.Pages.Navigation
         protected bool CanCreateSurvey { get; private set; }
         protected bool CanLeaveFeedback { get; private set; }
         protected bool CanUseHangfire { get; private set; }
+        protected bool IsDemoUser { get; private set; }
 
         protected override async Task OnInitializedAsync()
         {
@@ -44,6 +45,8 @@ namespace JwtIdentity.Client.Pages.Navigation
             var authState = await AuthStateProvider.GetAuthenticationStateAsync();
             var user = authState.User;
             IsAuthenticated = user.Identity?.IsAuthenticated ?? false;
+            var userName = user.Identity?.Name ?? string.Empty;
+            IsDemoUser = userName.StartsWith("DemoUser") && userName.EndsWith("@surveyshark.site");
             if (IsAuthenticated)
             {
                 IsAdmin = user.IsInRole("Admin");

--- a/JwtIdentity.Client/Pages/Survey/CreateSurvey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/CreateSurvey.razor.cs
@@ -14,7 +14,8 @@
         protected override async Task OnInitializedAsync()
         {
             var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-            IsDemoUser = authState.User.Identity?.Name == "DemoUser@surveyshark.site";
+            var userName = authState.User.Identity?.Name ?? string.Empty;
+            IsDemoUser = userName.StartsWith("DemoUser") && userName.EndsWith("@surveyshark.site");
         }
 
         protected bool ShowDemoStep(int step) => IsDemoUser && DemoStep == step;

--- a/JwtIdentity.Client/Pages/Survey/EditSurvey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/EditSurvey.razor.cs
@@ -102,7 +102,8 @@ namespace JwtIdentity.Client.Pages.Survey
             await LoadData();
 
             var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-            IsDemoUser = authState.User.Identity?.Name == "DemoUser@surveyshark.site";
+            var userName = authState.User.Identity?.Name ?? string.Empty;
+            IsDemoUser = userName.StartsWith("DemoUser") && userName.EndsWith("@surveyshark.site");
 
             if (await AuthService.GetUserId() != Survey.CreatedById)
             {

--- a/JwtIdentity.Client/Services/IAuthService.cs
+++ b/JwtIdentity.Client/Services/IAuthService.cs
@@ -4,6 +4,8 @@
     {
         Task<Response<ApplicationUserViewModel>> Login(ApplicationUserViewModel model);
 
+        Task<Response<ApplicationUserViewModel>> StartDemo();
+
         Task Logout();
 
         Task<int> GetUserId();


### PR DESCRIPTION
## Summary
- generate new demo users with GUID-based usernames via new `POST /api/auth/demo` endpoint
- schedule `DemoCleanup` Hangfire job to remove stale demo users and surveys
- keep login/register visible for demo sessions and detect demo users generically

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b502d0fc70832aad63f266e7453488