### PR TITLE
Refresh navigation menu after login

### DIFF
--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using JwtIdentity.Common.Auth;
+using Microsoft.AspNetCore.Components.Authorization;
 
 namespace JwtIdentity.Client.Pages.Navigation
 {
@@ -37,6 +38,7 @@ namespace JwtIdentity.Client.Pages.Navigation
             ((CustomAuthStateProvider)AuthStateProvider!).OnLoggedOut += UpdateLoggedIn;
             _authorizationHandler = CustomAuthorizationMessageHandler;
             _authorizationHandler.OnUnauthorized += UpdateLoggedIn;
+            AuthStateProvider.AuthenticationStateChanged += AuthStateChanged;
             _drawerOpen = false;
         }
 
@@ -78,7 +80,13 @@ namespace JwtIdentity.Client.Pages.Navigation
         protected async void UpdateLoggedIn()
         {
             await SetAuthFlagsAsync();
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
+        }
+
+        private async Task AuthStateChanged(Task<AuthenticationState> task)
+        {
+            await SetAuthFlagsAsync();
+            await InvokeAsync(StateHasChanged);
         }
 
         protected virtual void Dispose(bool disposing)
@@ -92,6 +100,7 @@ namespace JwtIdentity.Client.Pages.Navigation
                     {
                         _authorizationHandler.OnUnauthorized -= UpdateLoggedIn;
                     }
+                    AuthStateProvider.AuthenticationStateChanged -= AuthStateChanged;
                 }
                 _disposed = true;
             }


### PR DESCRIPTION
## Summary
- Update nav menu to react to authentication state changes so items like Admin and Logout appear immediately after login
- Invoke StateHasChanged safely and unsubscribe from events on dispose

## Testing
- `~/.dotnet/dotnet test` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b51c157044832a987bc2531299e6cc