### PR TITLE
Fix AuthStateChanged handler return type

### DIFF
--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor.cs
@@ -83,7 +83,7 @@ namespace JwtIdentity.Client.Pages.Navigation
             await InvokeAsync(StateHasChanged);
         }
 
-        private async Task AuthStateChanged(Task<AuthenticationState> task)
+        private async void AuthStateChanged(Task<AuthenticationState> task)
         {
             await SetAuthFlagsAsync();
             await InvokeAsync(StateHasChanged);


### PR DESCRIPTION
## Summary
- fix `AuthStateChanged` handler in MyNavMenu to return `void` for compatibility with `AuthenticationStateProvider.AuthenticationStateChanged`

## Testing
- ⚠️ `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b51e2b0c54832aaec4f066c9056734