### PR TITLE
Allow design-time creation of ApplicationDbContext

### DIFF
--- a/JwtIdentity/Data/ApplicationDbContext.cs
+++ b/JwtIdentity/Data/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Claims;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 
 namespace JwtIdentity.Data
 {
@@ -16,10 +17,10 @@ namespace JwtIdentity.Data
     {
         private readonly IHttpContextAccessor httpContextAccessor;
 
-        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options, IHttpContextAccessor httpContextAccessor)
-        : base(options)
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options, IHttpContextAccessor? httpContextAccessor = null)
+            : base(options)
         {
-            this.httpContextAccessor = httpContextAccessor;
+            this.httpContextAccessor = httpContextAccessor ?? new HttpContextAccessor();
         }
 
         public DbSet<ApplicationUser> ApplicationUsers { get; set; }

--- a/JwtIdentity/Data/DesignTimeDbContextFactory.cs
+++ b/JwtIdentity/Data/DesignTimeDbContextFactory.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Http;
+using System.IO;
+
+namespace JwtIdentity.Data
+{
+    public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext(string[] args)
+        {
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddJsonFile("appsettings.Development.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            var connectionString = configuration.GetConnectionString("DefaultConnection") ??
+                                    "Server=(localdb)\\mssqllocaldb;Database=JwtIdentity;Trusted_Connection=True;MultipleActiveResultSets=true";
+
+            var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+            optionsBuilder.UseSqlServer(connectionString);
+
+            return new ApplicationDbContext(optionsBuilder.Options, new HttpContextAccessor());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make `IHttpContextAccessor` optional in `ApplicationDbContext`
- add `DesignTimeDbContextFactory` so EF tools can construct the context during publish

## Testing
- `dotnet ef migrations list --project JwtIdentity/JwtIdentity.csproj`
- `dotnet test JwtIdentity.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b79e30402c832a9384c1266c1d06e6