### PR TITLE
Prevent redirect loop when API requests are unauthorized

### DIFF
--- a/JwtIdentity.Client/Services/CustomAuthorizationMessageHandler.cs
+++ b/JwtIdentity.Client/Services/CustomAuthorizationMessageHandler.cs
@@ -21,15 +21,19 @@ namespace JwtIdentity.Client.Services
         {
             var response = await base.SendAsync(request, cancellationToken);
 
-            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            // Avoid redirect loops when executing outside of a browser context (e.g., server prerendering)
+            if (OperatingSystem.IsBrowser())
             {
-                OnUnauthorized?.Invoke();
-                _navigationManager.NavigateTo("not-authorized");
-            }
-            else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
-            {
-                _navigationManager.NavigateTo("/");
-                _ = Snackbar.Add("The page does not exist.", Severity.Error);
+                if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                {
+                    OnUnauthorized?.Invoke();
+                    _navigationManager.NavigateTo("not-authorized");
+                }
+                else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    _navigationManager.NavigateTo("/");
+                    _ = Snackbar.Add("The page does not exist.", Severity.Error);
+                }
             }
 
             return response;


### PR DESCRIPTION
## Summary
- Avoid triggering client-side redirects in `CustomAuthorizationMessageHandler` when not running in a browser

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a8aa05d8832a94016072d7c0e6de