### PR TITLE
Fix stuck authorizing state

### DIFF
--- a/JwtIdentity.Client/Services/CustomAuthStateProvider.cs
+++ b/JwtIdentity.Client/Services/CustomAuthStateProvider.cs
@@ -97,11 +97,10 @@ namespace JwtIdentity.Client.Services
                     CurrentUser = await _apiService.GetAsync<ApplicationUserViewModel>($"{ApiEndpoints.ApplicationUser}/{userId}");
                 }
 
-                var authState = Task.FromResult(new AuthenticationState(user));
-
-                NotifyAuthenticationStateChanged(authState);
-
-                return await authState;
+                // Return the current authentication state without triggering an
+                // additional notification. Consumers are notified explicitly when
+                // login or logout events occur.
+                return new AuthenticationState(user);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- avoid redundant auth state notifications to prevent infinite authorization loops

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b7b234e4dc832aa584fcf6b2d34f38