### PR TITLE
Fix authentication token not attached to requests

### DIFF
--- a/JwtIdentity.Client/Services/CustomAuthorizationMessageHandler.cs
+++ b/JwtIdentity.Client/Services/CustomAuthorizationMessageHandler.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Headers;
+using Blazored.LocalStorage;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace JwtIdentity.Client.Services
@@ -6,19 +8,27 @@ namespace JwtIdentity.Client.Services
     {
         private readonly NavigationManager _navigationManager;
         private readonly IServiceProvider serviceProvider;
+        private readonly ILocalStorageService localStorage;
 
         private ISnackbar Snackbar => serviceProvider.GetRequiredService<ISnackbar>();
 
         public event Action OnUnauthorized;
 
-        public CustomAuthorizationMessageHandler(NavigationManager navigationManager, IServiceProvider serviceProvider)
+        public CustomAuthorizationMessageHandler(NavigationManager navigationManager, IServiceProvider serviceProvider, ILocalStorageService localStorage)
         {
             _navigationManager = navigationManager;
             this.serviceProvider = serviceProvider;
+            this.localStorage = localStorage;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            var token = await localStorage.GetItemAsync<string>("authToken");
+            if (!string.IsNullOrWhiteSpace(token) && request.Headers.Authorization is null)
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+
             var response = await base.SendAsync(request, cancellationToken);
 
             if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)


### PR DESCRIPTION
## Summary
- Ensure `CustomAuthorizationMessageHandler` attaches the bearer token from local storage to all outgoing requests
- Prevent unauthorized navigation that left the app stuck on "Authorizing"

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b65e4730832aa64bd2790a01798f