### PR TITLE
Guard JS interop during server-side rendering

### DIFF
--- a/JwtIdentity.Client/Services/ApiService.cs
+++ b/JwtIdentity.Client/Services/ApiService.cs
@@ -22,6 +22,14 @@ namespace JwtIdentity.Client.Services
         private HttpClient Client => _httpClient ??= _httpClientFactory.CreateClient("AuthorizedClient");
         private HttpClient PublicClient => _publicHttpClient ??= _httpClientFactory.CreateClient("PublicClient");
 
+        private void ShowSnackbar(string message, Severity severity)
+        {
+            if (OperatingSystem.IsBrowser())
+            {
+                _ = Snackbar.Add(message, severity);
+            }
+        }
+
         public ApiService(IHttpClientFactory httpClientFactory, NavigationManager navigationManager, IServiceProvider serviceProvider, IHttpContextAccessor? httpContextAccessor = null)
         {
             _options = new JsonSerializerOptions
@@ -50,19 +58,19 @@ namespace JwtIdentity.Client.Services
 
                 if (string.IsNullOrEmpty(error))
                 {
-                    _ = Snackbar.Add("There was a problem with the request", Severity.Error);
+                    ShowSnackbar("There was a problem with the request", Severity.Error);
                     return default;
                 }
                 else
                 {
-                    _ = Snackbar.Add(error, Severity.Error);
+                    ShowSnackbar(error, Severity.Error);
                     return default;
                 }
             }
 
             if (response.Content.Headers.ContentType?.MediaType == "text/html")
             {
-                _ = Snackbar.Add("Unexpected response. Please log in.", Severity.Error);
+                ShowSnackbar("Unexpected response. Please log in.", Severity.Error);
                 return default;
             }
 
@@ -78,19 +86,19 @@ namespace JwtIdentity.Client.Services
 
                 if (string.IsNullOrEmpty(error))
                 {
-                    _ = Snackbar.Add("There was a problem with the request", Severity.Error);
+                    ShowSnackbar("There was a problem with the request", Severity.Error);
                     return default;
                 }
                 else
                 {
-                    _ = Snackbar.Add(error, Severity.Error);
+                    ShowSnackbar(error, Severity.Error);
                     return default;
                 }
             }
 
             if (response.Content.Headers.ContentType?.MediaType == "text/html")
             {
-                _ = Snackbar.Add("Unexpected response. Please log in.", Severity.Error);
+                ShowSnackbar("Unexpected response. Please log in.", Severity.Error);
                 return default;
             }
 
@@ -122,11 +130,11 @@ namespace JwtIdentity.Client.Services
 
                     if (string.IsNullOrEmpty(error))
                     {
-                        _ = Snackbar.Add("There was a problem with the request", Severity.Error);
+                        ShowSnackbar("There was a problem with the request", Severity.Error);
                     }
                     else
                     {
-                        _ = Snackbar.Add(error, Severity.Error);
+                        ShowSnackbar(error, Severity.Error);
                     }
                 }
             }
@@ -145,11 +153,11 @@ namespace JwtIdentity.Client.Services
 
                 if (string.IsNullOrEmpty(error))
                 {
-                    _ = Snackbar.Add("There was a problem with the request", Severity.Error);
+                    ShowSnackbar("There was a problem with the request", Severity.Error);
                 }
                 else
                 {
-                    _ = Snackbar.Add(error, Severity.Error);
+                    ShowSnackbar(error, Severity.Error);
                 }
             }
 
@@ -167,18 +175,18 @@ namespace JwtIdentity.Client.Services
 
                 if (response.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    _ = Snackbar.Add("Invalid username or password", Severity.Error);
+                    ShowSnackbar("Invalid username or password", Severity.Error);
                     return default;
                 }
 
                 if (string.IsNullOrEmpty(error))
                 {
-                    _ = Snackbar.Add("There was a problem with the request", Severity.Error);
+                    ShowSnackbar("There was a problem with the request", Severity.Error);
                     return default;
                 }
                 else
                 {
-                    _ = Snackbar.Add(error, Severity.Error);
+                    ShowSnackbar(error, Severity.Error);
                     return default;
                 }
             }
@@ -193,7 +201,7 @@ namespace JwtIdentity.Client.Services
 
             if (!response.IsSuccessStatusCode)
             {
-                _ = Snackbar.Add("There was a problem with the request", Severity.Error);
+                ShowSnackbar("There was a problem with the request", Severity.Error);
                 return default;
             }
 
@@ -228,7 +236,7 @@ namespace JwtIdentity.Client.Services
             catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
                 navigationManager.NavigateTo("/");
-                _ = Snackbar.Add("The URL was invalid.", Severity.Error);
+                ShowSnackbar("The URL was invalid.", Severity.Error);
 
                 return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
             }

--- a/JwtIdentity.Client/Services/CustomAuthorizationMessageHandler.cs
+++ b/JwtIdentity.Client/Services/CustomAuthorizationMessageHandler.cs
@@ -23,10 +23,13 @@ namespace JwtIdentity.Client.Services
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var token = await localStorage.GetItemAsync<string>("authToken");
-            if (!string.IsNullOrWhiteSpace(token) && request.Headers.Authorization is null)
+            if (OperatingSystem.IsBrowser())
             {
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                var token = await localStorage.GetItemAsync<string>("authToken");
+                if (!string.IsNullOrWhiteSpace(token) && request.Headers.Authorization is null)
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                }
             }
 
             var response = await base.SendAsync(request, cancellationToken);
@@ -39,7 +42,10 @@ namespace JwtIdentity.Client.Services
             else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
                 _navigationManager.NavigateTo("/");
-                _ = Snackbar.Add("The page does not exist.", Severity.Error);
+                if (OperatingSystem.IsBrowser())
+                {
+                    _ = Snackbar.Add("The page does not exist.", Severity.Error);
+                }
             }
 
             return response;

--- a/bUnitTests/BUnitTestBase.cs
+++ b/bUnitTests/BUnitTestBase.cs
@@ -80,7 +80,10 @@ namespace JwtIdentity.BunitTests
         // Fake implementation for DI
         private class FakeCustomAuthorizationMessageHandler : JwtIdentity.Client.Services.CustomAuthorizationMessageHandler
         {
-            public FakeCustomAuthorizationMessageHandler() : base(new MockNavigationManager(), new ServiceCollection().BuildServiceProvider()) { }
+            public FakeCustomAuthorizationMessageHandler()
+                : base(new MockNavigationManager(), new ServiceCollection().BuildServiceProvider(), new Mock<ILocalStorageService>().Object)
+            {
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent JS interop during server-side rendering by skipping `localStorage` lookup in `CustomAuthorizationMessageHandler`
- only display snackbars when running in the browser
- update bUnit test harness for new handler signature

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b8e90008832a9b6fb9871b6d3183