### PR TITLE
Include roles in auth responses

### DIFF
--- a/JwtIdentity.Tests/ControllerTests/AuthControllerTests.cs
+++ b/JwtIdentity.Tests/ControllerTests/AuthControllerTests.cs
@@ -81,6 +81,10 @@ namespace JwtIdentity.Tests.ControllerTests
             MockUserManager.Setup(um => um.CheckPasswordAsync(user, model.Password))
                 .ReturnsAsync(true);
 
+            // Setup UserManager to return roles for the user
+            MockUserManager.Setup(um => um.GetRolesAsync(user))
+                .ReturnsAsync(new List<string> { "User" });
+
             // Setup ApiAuthService to generate a token
             MockApiAuthService.Setup(a => a.GenerateJwtToken(user))
                 .ReturnsAsync("test-jwt-token");
@@ -212,6 +216,10 @@ namespace JwtIdentity.Tests.ControllerTests
             MockUserManager.Setup(um => um.CheckPasswordAsync(anonymousUser, anonymousPassword))
                 .ReturnsAsync(true);
 
+            // Setup UserManager to return roles for the anonymous user
+            MockUserManager.Setup(um => um.GetRolesAsync(anonymousUser))
+                .ReturnsAsync(new List<string> { "User" });
+
             // Setup ApiAuthService to generate a token
             MockApiAuthService.Setup(a => a.GenerateJwtToken(anonymousUser))
                 .ReturnsAsync("anonymous-jwt-token");
@@ -264,6 +272,10 @@ namespace JwtIdentity.Tests.ControllerTests
 
             MockUserManager.Setup(um => um.CheckPasswordAsync(demoUser, anonymousPassword))
                 .ReturnsAsync(true);
+
+            // Setup UserManager to return roles for the demo user
+            MockUserManager.Setup(um => um.GetRolesAsync(demoUser))
+                .ReturnsAsync(new List<string> { "User" });
 
             MockApiAuthService.Setup(a => a.GenerateJwtToken(demoUser))
                 .ReturnsAsync("demo-jwt-token");


### PR DESCRIPTION
## Summary
- return user roles and permissions on login and demo user creation to prevent empty role updates
- adjust tests for role fetching

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ba3249d5cc832a8e16bac4c002fcb2