### PR TITLE
Fix multi-chart print behavior for survey results

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
@@ -240,18 +240,24 @@ namespace JwtIdentity.Client.Pages.Survey.Results
 
                         for (int i = 0; i < BarCharts.Count; i++)
                         {
-                            await Task.Delay(100);
-                            await BarCharts[i].ExportAsync(SelectedExportType, $"{SelectedChartType}_Chart_Q{i + 1}.{SelectedExportType}", Syncfusion.PdfExport.PdfPageOrientation.Landscape, true);
+                            if (BarCharts[i] != null)
+                            {
+                                await Task.Delay(100);
+                                await BarCharts[i].ExportAsync(SelectedExportType, $"{SelectedChartType}_Chart_Q{i + 1}.{SelectedExportType}", Syncfusion.PdfExport.PdfPageOrientation.Landscape, true);
+                            }
                         }
                         break;
                     case "Pie":
                         ChartWidth = "1000";
                         ChartHeight = "700";
 
-                        for (int i = 0; i < BarCharts.Count; i++)
+                        for (int i = 0; i < PieCharts.Count; i++)
                         {
-                            await Task.Delay(100);
-                            await PieCharts[i].ExportAsync(SelectedExportType, $"{SelectedChartType}_Chart_Q{i + 1}.{SelectedExportType}", Syncfusion.PdfExport.PdfPageOrientation.Landscape, true);
+                            if (PieCharts[i] != null)
+                            {
+                                await Task.Delay(100);
+                                await PieCharts[i].ExportAsync(SelectedExportType, $"{SelectedChartType}_Chart_Q{i + 1}.{SelectedExportType}", Syncfusion.PdfExport.PdfPageOrientation.Landscape, true);
+                            }
                         }
                         break;
                 }
@@ -278,10 +284,12 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                     }
                     else
                     {
-                        for (int i = 0; i < BarCharts.Count; i++)
+                        // Print all bar charts at once using the container reference
+                        var chart = BarCharts.FirstOrDefault(c => c != null);
+                        if (chart != null)
                         {
                             await Task.Delay(100);
-                            await BarCharts[i].PrintAsync(Element);
+                            await chart.PrintAsync(Element);
                         }
                     }
 
@@ -296,11 +304,12 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                     }
                     else
                     {
-                        for (int i = 0; i < PieCharts.Count; i++)
+                        // Print all pie charts at once using the container reference
+                        var chart = PieCharts.FirstOrDefault(c => c != null);
+                        if (chart != null)
                         {
                             await Task.Delay(100);
-
-                            await PieCharts[i].PrintAsync(Element);
+                            await chart.PrintAsync(Element);
                         }
                     }
                     break;


### PR DESCRIPTION
## Summary
- Avoid null references when exporting all charts
- Print all survey charts to a single document when no specific question is selected

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bde21ce290832a83fd49ce4e25f1ac