### PR TITLE
Fix printing of all survey charts

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
@@ -133,25 +133,29 @@
                     @switch (SelectedChartType)
                     {
                         case "Bar":
-                            <SfChart @ref="BarCharts[localIndex]" Title="@($"{localIndex + 1}. {question}")" SubTitle="@(GetSubtitle())" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
-                                <ChartTooltipSettings Enable="true" />
-                                <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category" />
-                                <ChartPrimaryYAxis Interval="1" />
-                                <ChartSeriesCollection>
-                                    <ChartSeries DataSource="@(BarChartDataForPrint[localIndex])" XName="X" YName="Y" Type="ChartSeriesType.Column" Fill="rgba(61, 44, 191, 1)" />
-                                </ChartSeriesCollection>
-                            </SfChart>
+                            <div class="print-chart">
+                                <SfChart @ref="BarCharts[localIndex]" Title="@($"{localIndex + 1}. {question}")" SubTitle="@(GetSubtitle())" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
+                                    <ChartTooltipSettings Enable="true" />
+                                    <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category" />
+                                    <ChartPrimaryYAxis Interval="1" />
+                                    <ChartSeriesCollection>
+                                        <ChartSeries DataSource="@(BarChartDataForPrint[localIndex])" XName="X" YName="Y" Type="ChartSeriesType.Column" Fill="rgba(61, 44, 191, 1)" />
+                                    </ChartSeriesCollection>
+                                </SfChart>
+                            </div>
                             break;
 
                         case "Pie":
-                            <SfAccumulationChart @ref="PieCharts[localIndex]" Title="@($"{localIndex + 1}. {question}")" SubTitle="@(GetSubtitle())" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
-                                <AccumulationChartTooltipSettings Enable="true" />
-                                <AccumulationChartSeriesCollection>
-                                    <AccumulationChartSeries DataSource="@(PieChartDataForPrint[localIndex])" XName="X" YName="Y" Radius="70%">
-                                        <AccumulationDataLabelSettings Visible="true" Position="AccumulationLabelPosition.Outside" Format="{value}%" />
-                                    </AccumulationChartSeries>
-                                </AccumulationChartSeriesCollection>
-                            </SfAccumulationChart>                            
+                            <div class="print-chart">
+                                <SfAccumulationChart @ref="PieCharts[localIndex]" Title="@($"{localIndex + 1}. {question}")" SubTitle="@(GetSubtitle())" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
+                                    <AccumulationChartTooltipSettings Enable="true" />
+                                    <AccumulationChartSeriesCollection>
+                                        <AccumulationChartSeries DataSource="@(PieChartDataForPrint[localIndex])" XName="X" YName="Y" Radius="70%">
+                                            <AccumulationDataLabelSettings Visible="true" Position="AccumulationLabelPosition.Outside" Format="{value}%" />
+                                        </AccumulationChartSeries>
+                                    </AccumulationChartSeriesCollection>
+                                </SfAccumulationChart>
+                            </div>
                             break;
                     }
                     questionIndex++;

--- a/JwtIdentity/wwwroot/js/site.js
+++ b/JwtIdentity/wwwroot/js/site.js
@@ -429,12 +429,19 @@ function clearCookieConsent() {
 function printElement(element) {
     const printWindow = window.open('', '_blank');
     printWindow.document.write('<html><head><title>Print</title>');
+    // Include existing head content for styles/scripts
     printWindow.document.write(document.head.innerHTML);
+    // Add print specific styles
+    printWindow.document.write('<style>@media print { .print-chart { break-after: page; page-break-after: always; } .print-chart:last-child { break-after: avoid; page-break-after: auto; } }</style>');
     printWindow.document.write('</head><body>');
-    printWindow.document.write(element.outerHTML);
+    // Only write the inner HTML of the element (charts)
+    printWindow.document.write(element.innerHTML);
     printWindow.document.write('</body></html>');
     printWindow.document.close();
-    printWindow.focus();
-    printWindow.print();
-    printWindow.close();
+    // Wait for the new window to finish loading before printing
+    printWindow.onload = () => {
+        printWindow.focus();
+        printWindow.print();
+        printWindow.close();
+    };
 }


### PR DESCRIPTION
## Summary
- Wrap each chart in a `print-chart` container so multiple charts print one per page.
- Improve client-side `printElement` helper to wait for load and add page-break styles when printing all charts.

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bdeb603120832a9b51290dec618481