### PR TITLE
Fix printing of multiple survey charts

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
@@ -133,7 +133,7 @@
                     @switch (SelectedChartType)
                     {
                         case "Bar":
-                            <div class="print-chart">
+                            <div class="print-chart" @ref="ChartElements[localIndex]">
                                 <SfChart @ref="BarCharts[localIndex]" Title="@($"{localIndex + 1}. {question}")" SubTitle="@(GetSubtitle())" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
                                     <ChartTooltipSettings Enable="true" />
                                     <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category" />
@@ -146,7 +146,7 @@
                             break;
 
                         case "Pie":
-                            <div class="print-chart">
+                            <div class="print-chart" @ref="ChartElements[localIndex]">
                                 <SfAccumulationChart @ref="PieCharts[localIndex]" Title="@($"{localIndex + 1}. {question}")" SubTitle="@(GetSubtitle())" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
                                     <AccumulationChartTooltipSettings Enable="true" />
                                     <AccumulationChartSeriesCollection>

--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
@@ -22,6 +22,8 @@ namespace JwtIdentity.Client.Pages.Survey.Results
 
         protected List<SfAccumulationChart> PieCharts { get; set; } = new();
 
+        protected List<ElementReference> ChartElements { get; set; } = new();
+
         protected List<SurveyDataViewModel> SurveyData { get; set; } = new();
 
         [Inject]
@@ -142,6 +144,7 @@ namespace JwtIdentity.Client.Pages.Survey.Results
 
             BarCharts.Clear();
             PieCharts.Clear();
+            ChartElements.Clear();
 
             if (question != null)
             {
@@ -157,11 +160,12 @@ namespace JwtIdentity.Client.Pages.Survey.Results
             }
             else
             {
-                // Initialize with null values
+                // Initialize with placeholders for chart and element references
                 for (int i = 0; i < SurveyData.Count; i++)
                 {
                     BarCharts.Add(null);
                     PieCharts.Add(null);
+                    ChartElements.Add(new());
                 }
 
                 GetDataToPrintAllCharts();
@@ -293,6 +297,8 @@ namespace JwtIdentity.Client.Pages.Survey.Results
             }
             else
             {
+                ElementReference[] elements = ChartElements.Where(e => !string.IsNullOrWhiteSpace(e.Id)).ToArray();
+
                 switch (SelectedChartType)
                 {
                     case "Bar":
@@ -306,7 +312,7 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                 }
 
                 await Task.Delay(100);
-                await JSRuntime.InvokeVoidAsync("printElement", Element);
+                await JSRuntime.InvokeVoidAsync("printCharts", elements);
             }
 
             ChartWidth = "100%";

--- a/JwtIdentity/wwwroot/js/site.js
+++ b/JwtIdentity/wwwroot/js/site.js
@@ -449,3 +449,29 @@ function printElement(element) {
         printWindow.close();
     };
 }
+
+// Print multiple chart elements sequentially
+function printCharts(elements) {
+    const printWindow = window.open('', '_blank');
+    printWindow.document.write('<html><head><title>Print</title>');
+    const headContent = Array.from(document.head.children)
+        .filter(node => node.tagName !== 'SCRIPT')
+        .map(node => node.outerHTML)
+        .join('');
+    printWindow.document.write(headContent);
+    printWindow.document.write('<style>@media print { .print-chart { break-after: page; page-break-after: always; } .print-chart:last-child { break-after: avoid; page-break-after: auto; } }</style>');
+    printWindow.document.write('</head><body>');
+    elements.forEach(e => {
+        if (e) {
+            const html = e.outerHTML.replace(/<script[\s\S]*?<\/script>/gi, '');
+            printWindow.document.write(html);
+        }
+    });
+    printWindow.document.write('</body></html>');
+    printWindow.document.close();
+    printWindow.onload = () => {
+        printWindow.focus();
+        printWindow.print();
+        printWindow.close();
+    };
+}


### PR DESCRIPTION
## Summary
- track DOM references for each chart when rendering all questions
- print all charts at once by sending chart elements to new `printCharts` helper

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf2e29f94832a84cb0f1491dff7d2