### PR TITLE
Ensure all charts are printed

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
@@ -133,7 +133,7 @@
                     @switch (SelectedChartType)
                     {
                         case "Bar":
-                            <div class="print-chart" @ref="ChartElements[localIndex]">
+                            <div class="print-chart">
                                 <SfChart @ref="BarCharts[localIndex]" Title="@($"{localIndex + 1}. {question}")" SubTitle="@(GetSubtitle())" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
                                     <ChartTooltipSettings Enable="true" />
                                     <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category" />
@@ -146,7 +146,7 @@
                             break;
 
                         case "Pie":
-                            <div class="print-chart" @ref="ChartElements[localIndex]">
+                            <div class="print-chart">
                                 <SfAccumulationChart @ref="PieCharts[localIndex]" Title="@($"{localIndex + 1}. {question}")" SubTitle="@(GetSubtitle())" Theme="@CurrentTheme" Width="@ChartWidth" Height="@ChartHeight">
                                     <AccumulationChartTooltipSettings Enable="true" />
                                     <AccumulationChartSeriesCollection>

--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
@@ -22,8 +22,6 @@ namespace JwtIdentity.Client.Pages.Survey.Results
 
         protected List<SfAccumulationChart> PieCharts { get; set; } = new();
 
-        protected List<ElementReference> ChartElements { get; set; } = new();
-
         protected List<SurveyDataViewModel> SurveyData { get; set; } = new();
 
         [Inject]
@@ -144,7 +142,6 @@ namespace JwtIdentity.Client.Pages.Survey.Results
 
             BarCharts.Clear();
             PieCharts.Clear();
-            ChartElements.Clear();
 
             if (question != null)
             {
@@ -160,12 +157,11 @@ namespace JwtIdentity.Client.Pages.Survey.Results
             }
             else
             {
-                // Initialize with placeholders for chart and element references
+                // Initialize with placeholders for chart references
                 for (int i = 0; i < SurveyData.Count; i++)
                 {
                     BarCharts.Add(null);
                     PieCharts.Add(null);
-                    ChartElements.Add(new());
                 }
 
                 GetDataToPrintAllCharts();
@@ -297,8 +293,6 @@ namespace JwtIdentity.Client.Pages.Survey.Results
             }
             else
             {
-                ElementReference[] elements = ChartElements.Where(e => !string.IsNullOrWhiteSpace(e.Id)).ToArray();
-
                 switch (SelectedChartType)
                 {
                     case "Bar":
@@ -312,7 +306,7 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                 }
 
                 await Task.Delay(100);
-                await JSRuntime.InvokeVoidAsync("printCharts", elements);
+                await JSRuntime.InvokeVoidAsync("printElement", Element);
             }
 
             ChartWidth = "100%";

--- a/JwtIdentity/wwwroot/js/site.js
+++ b/JwtIdentity/wwwroot/js/site.js
@@ -439,36 +439,11 @@ function printElement(element) {
     printWindow.document.write('<style>@media print { .print-chart { break-after: page; page-break-after: always; } .print-chart:last-child { break-after: avoid; page-break-after: auto; } }</style>');
     printWindow.document.write('</head><body>');
     // Only write the inner HTML of the element (charts)
-    printWindow.document.write(element.innerHTML);
+    const html = element.innerHTML.replace(/<script[\s\S]*?<\/script>/gi, '');
+    printWindow.document.write(html);
     printWindow.document.write('</body></html>');
     printWindow.document.close();
     // Wait for the new window to finish loading before printing
-    printWindow.onload = () => {
-        printWindow.focus();
-        printWindow.print();
-        printWindow.close();
-    };
-}
-
-// Print multiple chart elements sequentially
-function printCharts(elements) {
-    const printWindow = window.open('', '_blank');
-    printWindow.document.write('<html><head><title>Print</title>');
-    const headContent = Array.from(document.head.children)
-        .filter(node => node.tagName !== 'SCRIPT')
-        .map(node => node.outerHTML)
-        .join('');
-    printWindow.document.write(headContent);
-    printWindow.document.write('<style>@media print { .print-chart { break-after: page; page-break-after: always; } .print-chart:last-child { break-after: avoid; page-break-after: auto; } }</style>');
-    printWindow.document.write('</head><body>');
-    elements.forEach(e => {
-        if (e) {
-            const html = e.outerHTML.replace(/<script[\s\S]*?<\/script>/gi, '');
-            printWindow.document.write(html);
-        }
-    });
-    printWindow.document.write('</body></html>');
-    printWindow.document.close();
     printWindow.onload = () => {
         printWindow.focus();
         printWindow.print();


### PR DESCRIPTION
## Summary
- Print all survey charts by targeting the container instead of individual chart references
- Streamline Razor markup and remove unused references
- Simplify JS printing helper to strip scripts and handle multiple charts

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf6d2cca0832a9534dd95fd51f661