### PR TITLE
Print all survey charts

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
@@ -75,7 +75,7 @@
 
     @if (!IsLoading && SelectedQuestion != null)
     {
-        <span id="AllCharts" @ref="Element">
+        <span id="SingleChart" @ref="SingleChartElement">
             @switch (SelectedChartType)
             {
                 case "Bar":
@@ -124,7 +124,7 @@
     else if (!IsLoading && SurveyData.Count > 0 && BarChartDataForPrint.Count == SurveyData.Count && PieChartDataForPrint.Count == SurveyData.Count)
     {
         int questionIndex = 0;
-        <span id="AllCharts" @ref="Element">
+        <span id="AllCharts" @ref="AllChartsElement">
             <MudStack Spacing="1">
 
                 @foreach (var question in SurveyData.OrderBy(x => x.Question.QuestionNumber).Select(x => x.Question.Text))

--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
@@ -49,7 +49,8 @@ namespace JwtIdentity.Client.Pages.Survey.Results
 
         protected bool IsLoading { get; set; } = true;
 
-        protected ElementReference Element { get; set; }
+        protected ElementReference SingleChartElement { get; set; }
+        protected ElementReference AllChartsElement { get; set; }
 
         protected bool IsDemoUser { get; set; }
         protected int DemoStep { get; set; }
@@ -281,13 +282,13 @@ namespace JwtIdentity.Client.Pages.Survey.Results
 
                         await Task.Delay(100);
 
-                        await chartObj.PrintAsync(Element);
+                        await chartObj.PrintAsync(SingleChartElement);
                         break;
                     case "Pie":
                         ChartWidth = "1000";
                         ChartHeight = "700";
                         await Task.Delay(100);
-                        await pieChartObj.PrintAsync(Element);
+                        await pieChartObj.PrintAsync(SingleChartElement);
                         break;
                 }
             }
@@ -306,7 +307,7 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                 }
 
                 await Task.Delay(100);
-                await JSRuntime.InvokeVoidAsync("printElement", Element);
+                await JSRuntime.InvokeVoidAsync("printElement", AllChartsElement);
             }
 
             ChartWidth = "100%";


### PR DESCRIPTION
## Summary
- Separate element references for single and multi-question chart containers
- Use appropriate element reference during printing to send every chart to the dialog

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bdfa99a260832abb27aafd23835432