### PR TITLE
Fix printing for all survey charts

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor
@@ -124,7 +124,7 @@
     else if (!IsLoading && SurveyData.Count > 0 && BarChartDataForPrint.Count == SurveyData.Count && PieChartDataForPrint.Count == SurveyData.Count)
     {
         int questionIndex = 0;
-        <span id="AllCharts" @ref="AllChartsElement">
+        <div id="AllCharts" @ref="AllChartsElement">
             <MudStack Spacing="1">
 
                 @foreach (var question in SurveyData.OrderBy(x => x.Question.QuestionNumber).Select(x => x.Question.Text))
@@ -161,7 +161,7 @@
                     questionIndex++;
                 }
             </MudStack>
-        </span>
+        </div>
 
         @if (IsDemoUser && DemoStep == 3 && SelectedChartType == "Pie") NextDemoStep();
     }

--- a/JwtIdentity/wwwroot/js/site.js
+++ b/JwtIdentity/wwwroot/js/site.js
@@ -442,14 +442,14 @@ function printElement(element) {
 
     // Wait for the new window to finish loading before printing
     printWindow.onload = () => {
-        serializeElementToJson(element); // For debugging purposes
-        console.log('body', printWindow.document.body);
-        // Clone the entire element to preserve all charts
-        const clone = element.cloneNode(true);
-        // Remove any script tags from the clone for safety
-        clone.querySelectorAll('script').forEach(script => script.remove());
-        // Append the cloned content to the print window's body
-        printWindow.document.body.appendChild(clone);
+        // Clone each chart individually to ensure all charts are printed
+        const charts = element.querySelectorAll('.print-chart');
+        charts.forEach(chart => {
+            const clone = chart.cloneNode(true);
+            // Remove any script tags from the clone for safety
+            clone.querySelectorAll('script').forEach(script => script.remove());
+            printWindow.document.body.appendChild(clone);
+        });
 
         printWindow.focus();
         printWindow.print();


### PR DESCRIPTION
## Summary
- Use a div container for all charts to avoid inline printing issues
- Clone and append every chart when printing so all questions appear

## Testing
- `dotnet test` *(fails: Restore failed with 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68be14a75470832aab93ebac982de0b9