### PR TITLE
Fix print layout to show all survey charts

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -604,6 +604,16 @@ td.e-summarycell.e-templatecell.e-leftalign {
         visibility: visible;
     }
 
+    /* Allow the full document to expand for printing */
+    html,
+    body,
+    .app-container,
+    .main-content {
+        overflow: visible !important;
+        height: auto !important;
+        max-height: none !important;
+    }
+
     /* Position them correctly */
     .print-section {
         position: relative;


### PR DESCRIPTION
## Summary
- Allow document and main containers to expand during printing so all charts render

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bf6f98c6c4832abf698deb3b1d22a2