### PR TITLE
Fix blank pages when printing charts

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -596,12 +596,14 @@ td.e-summarycell.e-templatecell.e-leftalign {
     /* Hide everything by default */
     body * {
         visibility: hidden;
+        position: absolute;
     }
 
     /* Make only print-section content visible */
     .print-section,
     .print-section * {
         visibility: visible;
+        position: initial;
     }
 
     /* Allow the full document to expand for printing */
@@ -632,7 +634,13 @@ td.e-summarycell.e-templatecell.e-leftalign {
         page-break-after: always;
     }
 
+    .print-chart:first-child {
+        break-before: avoid;
+        page-break-before: auto;
+    }
+
     .print-chart:last-child {
+        break-after: avoid;
         page-break-after: auto;
     }
 


### PR DESCRIPTION
## Summary
- prevent hidden layout elements from creating blank pages in print view
- ensure first and last charts do not force extra page breaks

## Testing
- `dotnet test JwtIdentity.Tests/JwtIdentity.Tests.csproj -v n`

------
https://chatgpt.com/codex/tasks/task_e_68bf7253f660832ababcbaaf9a0c9fa6