### PR TITLE
Fix blank first and last pages when printing charts

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -596,12 +596,14 @@ td.e-summarycell.e-templatecell.e-leftalign {
     /* Hide everything by default */
     body * {
         visibility: hidden;
+        display: none;
     }
 
     /* Make only print-section content visible */
     .print-section,
     .print-section * {
         visibility: visible;
+        display: block;
     }
 
     /* Allow the full document to expand for printing */
@@ -616,7 +618,7 @@ td.e-summarycell.e-templatecell.e-leftalign {
 
     /* Position them correctly */
     .print-section {
-        position: relative;
+        position: absolute;
         top: 0;
         left: 0;
         width: 100%;


### PR DESCRIPTION
## Summary
- Ensure only chart content is displayed in print layout
- Absolutely position print section to avoid extra pages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bf777686f8832a8c6411e6d52ee7be