### PR TITLE
Avoid extra blank page when printing charts

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -631,12 +631,11 @@ td.e-summarycell.e-templatecell.e-leftalign {
 
     /* Each chart prints on its own page */
     .print-chart {
-        page-break-after: always;
         page-break-inside: avoid; /* keep each chart whole */
     }
 
-    .print-chart:last-child {
-        page-break-after: auto;
+    .print-chart:not(:last-child) {
+        page-break-after: always;
     }
 
     #AllCharts,

--- a/JwtIdentity/wwwroot/js/site.js
+++ b/JwtIdentity/wwwroot/js/site.js
@@ -436,7 +436,7 @@ function printElement(element) {
         .join('');
     printWindow.document.write(headContent);
     // Add print specific styles
-    printWindow.document.write('<style>@media print { .print-chart { break-after: page; page-break-after: always; } .print-chart:last-child { break-after: avoid; page-break-after: auto; } }</style>');
+    printWindow.document.write('<style>@media print { .print-chart { break-inside: avoid; page-break-inside: avoid; } .print-chart:not(:last-child) { break-after: page; page-break-after: always; } }</style>');
     printWindow.document.write('</head><body></body></html>');
     printWindow.document.close();
 


### PR DESCRIPTION
## Summary
- ensure each chart except the last triggers a page break
- update print helper to mirror CSS rules

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bf87d44f48832a832a166425289659