### PR TITLE
Handle blocked print window

### DIFF
--- a/JwtIdentity/wwwroot/js/site.js
+++ b/JwtIdentity/wwwroot/js/site.js
@@ -428,6 +428,10 @@ function clearCookieConsent() {
 // Print the supplied element and all of its contents
 function printElement(element) {
     const printWindow = window.open('', '_blank');
+    if (!printWindow || !printWindow.document) {
+        console.error('Unable to open print window. It may have been blocked by the browser.');
+        return;
+    }
     printWindow.document.write('<html><head><title>Print</title>');
     // Include existing head content for styles but exclude scripts
     const headContent = Array.from(document.head.children)


### PR DESCRIPTION
## Summary
- avoid accessing `document` when `window.open` is blocked during printing

## Testing
- `dotnet build`
- `dotnet test > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68bf9030abf4832ab8e3f8499663b144