### PR TITLE
Switch to printPage for multi-chart printing

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
@@ -309,7 +309,7 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                 StateHasChanged();
                 await Task.Delay(5000);
 
-                await JSRuntime.InvokeVoidAsync("printElement", AllChartsElement);
+                await JSRuntime.InvokeVoidAsync("printPage");
             }
 
             ChartWidth = "100%";

--- a/JwtIdentity/wwwroot/css/app-dark.css
+++ b/JwtIdentity/wwwroot/css/app-dark.css
@@ -170,3 +170,48 @@ pre[class*=language-] {
 .signup-section {
     background-color: var(--signup-bg);
 }
+
+@media print {
+    body * {
+        visibility: hidden;
+    }
+
+    .print-section,
+    .print-section * {
+        visibility: visible;
+    }
+
+    html,
+    body,
+    .app-container,
+    .main-content {
+        overflow: visible !important;
+        height: auto !important;
+        max-height: none !important;
+    }
+
+    .print-section {
+        width: 100%;
+    }
+
+    .print-section .mud-stack {
+        display: block;
+    }
+
+    .print-chart {
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
+
+    .print-chart:not(:last-child) {
+        break-after: page;
+        page-break-after: always;
+    }
+
+    #AllCharts,
+    .print-section {
+        overflow: visible;
+        height: auto;
+        max-height: none;
+    }
+}

--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -596,14 +596,12 @@ td.e-summarycell.e-templatecell.e-leftalign {
     /* Hide everything by default */
     body * {
         visibility: hidden;
-        display: none;
     }
 
     /* Make only print-section content visible */
     .print-section,
     .print-section * {
         visibility: visible;
-        display: block;
     }
 
     /* Allow the full document to expand for printing */
@@ -618,9 +616,6 @@ td.e-summarycell.e-templatecell.e-leftalign {
 
     /* Position them correctly */
     .print-section {
-        position: absolute;
-        top: 0;
-        left: 0;
         width: 100%;
     }
 
@@ -631,10 +626,12 @@ td.e-summarycell.e-templatecell.e-leftalign {
 
     /* Each chart prints on its own page */
     .print-chart {
-        page-break-inside: avoid; /* keep each chart whole */
+        break-inside: avoid;
+        page-break-inside: avoid;
     }
 
     .print-chart:not(:last-child) {
+        break-after: page;
         page-break-after: always;
     }
 

--- a/JwtIdentity/wwwroot/js/site.js
+++ b/JwtIdentity/wwwroot/js/site.js
@@ -426,67 +426,6 @@ function clearCookieConsent() {
 }
 
 // Print the supplied element and all of its contents
-function printElement(element) {
-    const printWindow = window.open('', '_blank');
-    if (!printWindow || !printWindow.document) {
-        console.error('Unable to open print window. It may have been blocked by the browser.');
-        return;
-    }
-    printWindow.document.write('<html><head><title>Print</title>');
-    // Include existing head content for styles but exclude scripts
-    const headContent = Array.from(document.head.children)
-        .filter(node => node.tagName !== 'SCRIPT')
-        .map(node => node.outerHTML)
-        .join('');
-    printWindow.document.write(headContent);
-    // Add print specific styles
-    printWindow.document.write('<style>@media print { .print-chart { break-inside: avoid; page-break-inside: avoid; } .print-chart:not(:last-child) { break-after: page; page-break-after: always; } }</style>');
-    printWindow.document.write('</head><body></body></html>');
-    printWindow.document.close();
-
-    // Wait for the new window to finish loading before printing
-    printWindow.onload = () => {
-        // Clone each chart individually to ensure all charts are printed
-        const charts = element.querySelectorAll('.print-chart');
-        charts.forEach(chart => {
-            const clone = chart.cloneNode(true);
-            // Remove any script tags from the clone for safety
-            clone.querySelectorAll('script').forEach(script => script.remove());
-            printWindow.document.body.appendChild(clone);
-        });
-
-        printWindow.focus();
-        printWindow.print();
-        printWindow.close();
-    };
+function printPage() {
+    window.print();
 }
-
-// Create a function to serialize the entire element from the printElement function as json and write it to the console
-function serializeElementToJson(element) {
-    function serializeNode(node) {
-        const obj = {
-            nodeType: node.nodeType,
-            nodeName: node.nodeName,
-        };
-        if (node.nodeType === Node.ELEMENT_NODE) {
-            obj.attributes = {};
-            for (let attr of node.attributes) {
-                obj.attributes[attr.name] = attr.value;
-            }
-            obj.children = [];
-            for (let child of node.childNodes) {
-                obj.children.push(serializeNode(child));
-            }
-        } else if (node.nodeType === Node.TEXT_NODE) {
-            obj.textContent = node.textContent;
-        }
-        return obj;
-    }
-    const serialized = serializeNode(element);
-    console.log(JSON.stringify(serialized, null, 2));
-    return serialized;
-}
-
-    function printPage() {
-        window.print();
-  }


### PR DESCRIPTION
## Summary
- Replace `printElement` usage with `printPage`
- Adjust print stylesheet to hide non-chart content and page-break charts
- Add equivalent print rules for dark theme and remove unused JS

## Testing
- `dotnet test` *(fails: command hung during execution)*

------
https://chatgpt.com/codex/tasks/task_e_68bf932ba8a8832a968aa849b339c59d