### PR TITLE
Fix blank pages on chart print

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -596,12 +596,14 @@ td.e-summarycell.e-templatecell.e-leftalign {
     /* Hide everything by default */
     body * {
         visibility: hidden;
+        height: 0 !important;
     }
 
     /* Make only print-section content visible */
     .print-section,
     .print-section * {
         visibility: visible;
+        height: auto !important;
     }
 
     /* Allow the full document to expand for printing */
@@ -617,6 +619,9 @@ td.e-summarycell.e-templatecell.e-leftalign {
     /* Position them correctly */
     .print-section {
         width: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
     }
 
     /* Ensure flex layouts don't truncate content when printing */


### PR DESCRIPTION
## Summary
- avoid blank pages when printing charts by collapsing non-print elements and anchoring print section to page top

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bf95e51464832a96e511c0c75f1cf1