### PR TITLE
Fix chart printing layout for multi-page exports

### DIFF
--- a/JwtIdentity/wwwroot/css/app-dark.css
+++ b/JwtIdentity/wwwroot/css/app-dark.css
@@ -174,6 +174,7 @@ pre[class*=language-] {
 @media print {
     body * {
         visibility: hidden;
+        height: 0 !important;
     }
 
     .print-section,

--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -616,12 +616,9 @@ td.e-summarycell.e-templatecell.e-leftalign {
         max-height: none !important;
     }
 
-    /* Position them correctly */
+    /* Ensure charts print in document flow */
     .print-section {
         width: 100%;
-        position: absolute;
-        top: 0;
-        left: 0;
     }
 
     /* Ensure flex layouts don't truncate content when printing */


### PR DESCRIPTION
## Summary
- remove absolute positioning from chart print section so charts render on every page
- collapse hidden content in dark theme to prevent blank printed pages

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bf98754778832aa1d63e8665a696e9