### PR TITLE
fix: move print styles and resolve blank chart pages

### DIFF
--- a/JwtIdentity/wwwroot/css/app-dark.css
+++ b/JwtIdentity/wwwroot/css/app-dark.css
@@ -84,11 +84,6 @@ code[class*=language-], pre[class*=language-] {
         background: #b3d4fc
     }
 
-@media print {
-    code[class*=language-], pre[class*=language-] {
-        text-shadow: none
-    }
-}
 
 pre[class*=language-] {
     padding: 1em;
@@ -171,48 +166,3 @@ pre[class*=language-] {
     background-color: var(--signup-bg);
 }
 
-@media print {
-    body * {
-        visibility: hidden;
-        height: 0 !important;
-    }
-
-    .print-section,
-    .print-section * {
-        visibility: visible;
-    }
-
-    html,
-    body,
-    .app-container,
-    .main-content {
-        overflow: visible !important;
-        height: auto !important;
-        max-height: none !important;
-    }
-
-    .print-section {
-        width: 100%;
-    }
-
-    .print-section .mud-stack {
-        display: block;
-    }
-
-    .print-chart {
-        break-inside: avoid;
-        page-break-inside: avoid;
-    }
-
-    .print-chart:not(:last-child) {
-        break-after: page;
-        page-break-after: always;
-    }
-
-    #AllCharts,
-    .print-section {
-        overflow: visible;
-        height: auto;
-        max-height: none;
-    }
-}

--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -596,14 +596,18 @@ td.e-summarycell.e-templatecell.e-leftalign {
     /* Hide everything by default */
     body * {
         visibility: hidden;
-        height: 0 !important;
     }
 
     /* Make only print-section content visible */
     .print-section,
     .print-section * {
         visibility: visible;
-        height: auto !important;
+    }
+
+    /* Remove code block text shadows for clearer printing */
+    code[class*=language-],
+    pre[class*=language-] {
+        text-shadow: none;
     }
 
     /* Allow the full document to expand for printing */
@@ -612,8 +616,6 @@ td.e-summarycell.e-templatecell.e-leftalign {
     .app-container,
     .main-content {
         overflow: visible !important;
-        height: auto !important;
-        max-height: none !important;
     }
 
     /* Ensure charts print in document flow */
@@ -640,7 +642,5 @@ td.e-summarycell.e-templatecell.e-leftalign {
     #AllCharts,
     .print-section {
         overflow: visible;
-        height: auto;
-        max-height: none;
     }
 }


### PR DESCRIPTION
## Summary
- move `@media print` block from dark theme to shared stylesheet so dark CSS only contains theme rules
- adjust print stylesheet to keep chart elements visible, fixing blank pages when printing

## Testing
- `dotnet test --no-build --nologo`

------
https://chatgpt.com/codex/tasks/task_e_68bf9b7cf2a0832a98d3427dd23e1bf4