### PR TITLE
Fix blank first page when printing charts

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -618,9 +618,12 @@ td.e-summarycell.e-templatecell.e-leftalign {
         overflow: visible !important;
     }
 
-    /* Ensure charts print in document flow */
+    /* Ensure charts print in document flow and start at the top of the first page */
     .print-section {
         width: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
     }
 
     /* Ensure flex layouts don't truncate content when printing */


### PR DESCRIPTION
## Summary
- Anchor printed chart container to the top-left so the first page isn't empty

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c09a3dd4fc832abcfd5e3b8b2ec005