### PR TITLE
Adjust chart print scaling

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Results/BarChart.razor.cs
@@ -281,13 +281,14 @@ namespace JwtIdentity.Client.Pages.Survey.Results
                         ChartHeight = "700";
 
                         await Task.Delay(100);
-
+                        await JSRuntime.InvokeVoidAsync("adjustChartsForPrint");
                         await chartObj.PrintAsync(SingleChartElement);
                         break;
                     case "Pie":
                         ChartWidth = "1000";
                         ChartHeight = "700";
                         await Task.Delay(100);
+                        await JSRuntime.InvokeVoidAsync("adjustChartsForPrint");
                         await pieChartObj.PrintAsync(SingleChartElement);
                         break;
                 }
@@ -308,7 +309,7 @@ namespace JwtIdentity.Client.Pages.Survey.Results
 
                 StateHasChanged();
                 await Task.Delay(5000);
-
+                await JSRuntime.InvokeVoidAsync("adjustChartsForPrint");
                 await JSRuntime.InvokeVoidAsync("printPage");
             }
 

--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -646,4 +646,33 @@ td.e-summarycell.e-templatecell.e-leftalign {
     .print-section {
         overflow: visible;
     }
+
+    /* Scale charts to fill the printable area based on aspect ratio */
+    #SingleChart.fill-width,
+    .print-chart.fill-width {
+        width: 100%;
+        height: auto;
+    }
+
+    #SingleChart.fill-width svg,
+    #SingleChart.fill-width canvas,
+    .print-chart.fill-width svg,
+    .print-chart.fill-width canvas {
+        width: 100% !important;
+        height: auto !important;
+    }
+
+    #SingleChart.fill-height,
+    .print-chart.fill-height {
+        height: 100vh;
+        width: auto;
+    }
+
+    #SingleChart.fill-height svg,
+    #SingleChart.fill-height canvas,
+    .print-chart.fill-height svg,
+    .print-chart.fill-height canvas {
+        height: 100vh !important;
+        width: auto !important;
+    }
 }

--- a/JwtIdentity/wwwroot/js/site.js
+++ b/JwtIdentity/wwwroot/js/site.js
@@ -426,6 +426,20 @@ function clearCookieConsent() {
 }
 
 // Print the supplied element and all of its contents
+function adjustChartsForPrint() {
+    const charts = document.querySelectorAll('#SingleChart, .print-chart');
+    charts.forEach(chart => {
+        chart.classList.remove('fill-width', 'fill-height');
+        const rect = chart.getBoundingClientRect();
+        if (rect.width > rect.height) {
+            chart.classList.add('fill-width');
+        } else {
+            chart.classList.add('fill-height');
+        }
+    });
+}
+
 function printPage() {
+    adjustChartsForPrint();
     window.print();
 }


### PR DESCRIPTION
## Summary
- Scale charts when printing to fill width or height based on aspect ratio
- Add JavaScript helper to mark charts as width- or height-filling before print
- Hook into chart print workflow to apply dynamic sizing

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c09f2e63c8832a8140c4cf169bb500