### PR TITLE
Fix hidden x-axis when printing multiple charts

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -635,6 +635,7 @@ td.e-summarycell.e-templatecell.e-leftalign {
     .print-chart {
         break-inside: avoid;
         page-break-inside: avoid;
+        padding-bottom: 40px;
     }
 
     .print-chart:not(:last-child) {


### PR DESCRIPTION
## Summary
- add bottom padding to chart containers so x-axis renders in print view

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a1d5a2b8832a99986c555397555b