### PR TITLE
Fix printing of all bar charts showing blank pages

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -621,9 +621,6 @@ td.e-summarycell.e-templatecell.e-leftalign {
     /* Ensure charts print in document flow and start at the top of the first page */
     .print-section {
         width: 100%;
-        position: absolute;
-        top: 0;
-        left: 0;
     }
 
     /* Ensure flex layouts don't truncate content when printing */


### PR DESCRIPTION
## Summary
- ensure chart pages print in document flow so each bar chart renders with visible axes

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a6ff0604832a9e7ae1f19a0d2973