### PR TITLE
Avoid blank first page when printing multiple charts

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -621,6 +621,9 @@ td.e-summarycell.e-templatecell.e-leftalign {
     /* Ensure charts print in document flow */
     .print-section {
         width: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
     }
 
     /* Ensure flex layouts don't truncate content when printing */


### PR DESCRIPTION
## Summary
- Prevent blank page before charts by positioning print section at top during print

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c208c33790832a855e90b17bb012ba