### PR TITLE
Fix missing header on first printed bar chart

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -596,12 +596,14 @@ td.e-summarycell.e-templatecell.e-leftalign {
     /* Hide everything by default */
     body * {
         visibility: hidden;
+        display: none;
     }
 
     /* Make only print-section content visible */
     .print-section,
     .print-section * {
         visibility: visible;
+        display: block;
     }
 
     /* Remove code block text shadows for clearer printing */
@@ -621,9 +623,7 @@ td.e-summarycell.e-templatecell.e-leftalign {
     /* Ensure charts print in document flow */
     .print-section {
         width: 100%;
-        position: absolute;
-        top: 0;
-        left: 0;
+        position: static;
     }
 
     /* Ensure flex layouts don't truncate content when printing */


### PR DESCRIPTION
## Summary
- ensure only chart section is rendered when printing
- adjust print layout positioning to keep first chart title and subtitle visible

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c36fc9c3e0832ab1c4dc505808de00