### PR TITLE
Fix blank page when printing charts

### DIFF
--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -596,12 +596,14 @@ td.e-summarycell.e-templatecell.e-leftalign {
     /* Hide everything by default */
     body * {
         visibility: hidden;
+        display: none;
     }
 
     /* Make only print-section content visible */
     .print-section,
     .print-section * {
         visibility: visible;
+        display: revert;
     }
 
     /* Remove code block text shadows for clearer printing */


### PR DESCRIPTION
## Summary
- prevent non-chart elements from reserving space when printing, ensuring the first chart appears on page 1

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c37775ed90832aaa78dc91f90967fc