### PR TITLE
Generate demo survey responses for demo user surveys

### DIFF
--- a/JwtIdentity.Tests/ControllerTests/SurveyControllerTests.cs
+++ b/JwtIdentity.Tests/ControllerTests/SurveyControllerTests.cs
@@ -18,6 +18,7 @@ namespace JwtIdentity.Tests.ControllerTests
         private List<Question> _mockQuestions = null!;
         private List<ApplicationUser> _mockUsers = null!;
         private Mock<IOpenAi> MockOpenAiService = null!;
+        private Mock<ISurveyService> MockSurveyService = null!;
 
         [SetUp]
         public override void BaseSetUp()
@@ -31,7 +32,8 @@ namespace JwtIdentity.Tests.ControllerTests
             MockOpenAiService.Setup(x => x.GenerateSurveyAsync(It.IsAny<string>(), "")).ReturnsAsync(new SurveyViewModel { Questions = new List<QuestionViewModel>() });
             MockEmailService.Setup(e => e.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
             MockConfiguration.Setup(c => c["EmailSettings:CustomerServiceEmail"]).Returns("admin@example.com");
-            _controller = new SurveyController(MockDbContext, MockMapper.Object, MockApiAuthService.Object, MockLogger.Object, MockOpenAiService.Object, MockEmailService.Object, MockConfiguration.Object)
+            MockSurveyService = new Mock<ISurveyService>();
+            _controller = new SurveyController(MockDbContext, MockMapper.Object, MockApiAuthService.Object, MockLogger.Object, MockOpenAiService.Object, MockEmailService.Object, MockConfiguration.Object, MockSurveyService.Object)
             {
                 ControllerContext = new ControllerContext { HttpContext = HttpContext }
             };

--- a/JwtIdentity/Controllers/SurveyController.cs
+++ b/JwtIdentity/Controllers/SurveyController.cs
@@ -13,8 +13,9 @@ namespace JwtIdentity.Controllers
         private readonly IOpenAi _openAiService;
         private readonly IEmailService _emailService;
         private readonly IConfiguration _configuration;
+        private readonly ISurveyService _surveyService;
 
-        public SurveyController(ApplicationDbContext context, IMapper mapper, IApiAuthService authService, ILogger<SurveyController> logger, IOpenAi openAiService, IEmailService emailService, IConfiguration configuration)
+        public SurveyController(ApplicationDbContext context, IMapper mapper, IApiAuthService authService, ILogger<SurveyController> logger, IOpenAi openAiService, IEmailService emailService, IConfiguration configuration, ISurveyService surveyService)
         {
             _context = context;
             _mapper = mapper;
@@ -23,6 +24,7 @@ namespace JwtIdentity.Controllers
             _openAiService = openAiService;
             _emailService = emailService;
             _configuration = configuration;
+            _surveyService = surveyService;
         }
 
         // GET: api/Survey/5
@@ -519,6 +521,11 @@ namespace JwtIdentity.Controllers
                     {
                         var userBody = $"<p>Congratulations {userName}, your survey has been published!</p><p>Title: {survey.Title}</p><p>Description: {survey.Description}</p>";
                         await _emailService.SendEmailAsync(user.Email, $"Survey Published: {survey.Title}", userBody);
+                    }
+
+                    if (user?.Email != null && user.Email.Contains("DemoUser", StringComparison.OrdinalIgnoreCase))
+                    {
+                        await _surveyService.GenerateDemoSurveyResponsesAsync(survey);
                     }
                 }
 

--- a/JwtIdentity/Services/ISurveyService.cs
+++ b/JwtIdentity/Services/ISurveyService.cs
@@ -3,5 +3,6 @@
     public interface ISurveyService
     {
         Survey GetSurvey(string guid);
+        Task GenerateDemoSurveyResponsesAsync(Survey survey, int numberOfUsers = 20);
     }
 }

--- a/JwtIdentity/Services/SurveyService.cs
+++ b/JwtIdentity/Services/SurveyService.cs
@@ -42,5 +42,149 @@
                 throw;
             }
         }
+
+        public async Task GenerateDemoSurveyResponsesAsync(Survey survey, int numberOfUsers = 20)
+        {
+            try
+            {
+                if (survey == null)
+                {
+                    _logger.LogWarning("Survey is null when attempting to generate demo responses");
+                    return;
+                }
+
+                // Reload survey with questions and options
+                survey = await _dbContext.Surveys
+                    .Where(s => s.Id == survey.Id)
+                    .Include(s => s.Questions)
+                    .FirstOrDefaultAsync();
+
+                if (survey == null)
+                {
+                    _logger.LogWarning("Survey with ID {SurveyId} not found when generating demo responses", survey?.Id);
+                    return;
+                }
+
+                // Load options for multiple choice and select-all questions
+                var mcIds = survey.Questions
+                    .OfType<MultipleChoiceQuestion>()
+                    .Select(q => q.Id)
+                    .ToList();
+
+                if (mcIds.Any())
+                {
+                    await _dbContext.Questions
+                        .OfType<MultipleChoiceQuestion>()
+                        .Where(q => mcIds.Contains(q.Id))
+                        .Include(q => q.Options)
+                        .LoadAsync();
+                }
+
+                var satIds = survey.Questions
+                    .OfType<SelectAllThatApplyQuestion>()
+                    .Select(q => q.Id)
+                    .ToList();
+
+                if (satIds.Any())
+                {
+                    await _dbContext.Questions
+                        .OfType<SelectAllThatApplyQuestion>()
+                        .Where(q => satIds.Contains(q.Id))
+                        .Include(q => q.Options)
+                        .LoadAsync();
+                }
+
+                var random = new Random();
+
+                for (int i = 0; i < numberOfUsers; i++)
+                {
+                    var userGuid = Guid.NewGuid().ToString();
+                    var email = $"anonymous_{userGuid}@surveyshark.site";
+
+                    var anonUser = new ApplicationUser
+                    {
+                        UserName = email,
+                        NormalizedUserName = email.ToUpperInvariant(),
+                        Email = email,
+                        NormalizedEmail = email.ToUpperInvariant(),
+                        EmailConfirmed = true,
+                        SecurityStamp = string.Empty,
+                        Theme = "light",
+                        CreatedDate = DateTime.UtcNow,
+                        UpdatedDate = DateTime.UtcNow
+                    };
+
+                    _dbContext.Users.Add(anonUser);
+                    await _dbContext.SaveChangesAsync();
+
+                    foreach (var question in survey.Questions)
+                    {
+                        Answer answer = question.QuestionType switch
+                        {
+                            QuestionType.Text => new TextAnswer
+                            {
+                                QuestionId = question.Id,
+                                Text = $"Sample answer {random.Next(1, 1000)}",
+                                Complete = true,
+                                CreatedById = anonUser.Id,
+                                IpAddress = "127.0.0.1"
+                            },
+                            QuestionType.TrueFalse => new TrueFalseAnswer
+                            {
+                                QuestionId = question.Id,
+                                Value = random.Next(0, 2) == 0,
+                                Complete = true,
+                                CreatedById = anonUser.Id,
+                                IpAddress = "127.0.0.1"
+                            },
+                            QuestionType.MultipleChoice => new MultipleChoiceAnswer
+                            {
+                                QuestionId = question.Id,
+                                SelectedOptionId = ((MultipleChoiceQuestion)question).Options
+                                    [random.Next(((MultipleChoiceQuestion)question).Options.Count)].Id,
+                                Complete = true,
+                                CreatedById = anonUser.Id,
+                                IpAddress = "127.0.0.1"
+                            },
+                            QuestionType.Rating1To10 => new Rating1To10Answer
+                            {
+                                QuestionId = question.Id,
+                                SelectedOptionId = random.Next(1, 11),
+                                Complete = true,
+                                CreatedById = anonUser.Id,
+                                IpAddress = "127.0.0.1"
+                            },
+                            QuestionType.SelectAllThatApply => new SelectAllThatApplyAnswer
+                            {
+                                QuestionId = question.Id,
+                                SelectedOptionIds = string.Join(",", ((SelectAllThatApplyQuestion)question).Options
+                                    .Where(_ => random.Next(0, 2) == 1)
+                                    .Select(o => o.Id)
+                                    .DefaultIfEmpty(((SelectAllThatApplyQuestion)question).Options
+                                        [random.Next(((SelectAllThatApplyQuestion)question).Options.Count)].Id)),
+                                Complete = true,
+                                CreatedById = anonUser.Id,
+                                IpAddress = "127.0.0.1"
+                            },
+                            _ => null
+                        };
+
+                        if (answer != null)
+                        {
+                            _dbContext.Answers.Add(answer);
+                        }
+                    }
+
+                    await _dbContext.SaveChangesAsync();
+                }
+
+                _logger.LogInformation("Generated {Count} demo responses for survey {SurveyId}", numberOfUsers, survey.Id);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error generating demo survey responses for survey {SurveyId}", survey?.Id);
+                throw;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- create SurveyService method to seed 20 anonymous users with random answers
- invoke demo response generation when a demo user publishes a survey
- adjust SurveyController tests for new dependency

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c5f0fb8634832ab108e2ddca99a695