### PR TITLE
Fix survey result aggregates to consider all filtered rows

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/Results/Filter.razor
+++ b/JwtIdentity.Client/Pages/Survey/Results/Filter.razor
@@ -62,12 +62,12 @@
                             {
                                 <GridAggregateColumn Field=@(_propertyMap[q.Id].ToString()) Type="Syncfusion.Blazor.Grids.AggregateType.Count">
                                     <FooterTemplate>
-                                        
-                                        @{
-                                            var aggregate = (context as AggregateTemplateContext);
-                                            double rowCount = double.TryParse(aggregate.Count, out rowCount) ? rowCount : 0;
 
-                                            <p>Row Count: @aggregate.Count</p>
+                                        @{
+                                            double rowCount = TotalRowCount;
+
+        
+                                            <p>Row Count: @TotalRowCount</p>
 
                                             @* inside your FooterTemplate *@
                                             @if (q is MultipleChoiceQuestionViewModel mcq)
@@ -78,7 +78,7 @@
                                                     && d1.TryGetValue(opt.Id, out var c1)
                                                     ? c1 : 0;
 
-                                                    string percentage = (count / rowCount).ToString("P2");
+                                                    string percentage = rowCount == 0 ? "0.00%" : (count / rowCount).ToString("P2");
 
                                                     <p>@opt.OptionText: @count (@percentage)</p>
                                                 }
@@ -90,7 +90,7 @@
                                                     foreach (var opt in saq.Options.OrderBy(o => o.Order))
                                                     {
                                                         var count = dict.TryGetValue(opt.Id, out var c) ? c : 0;
-                                                        string percentage = (count / rowCount).ToString("P2");
+                                                        string percentage = rowCount == 0 ? "0.00%" : (count / rowCount).ToString("P2");
                                                         <p>@opt.OptionText: @count (@percentage)</p>
                                                     }
                                                 }
@@ -101,8 +101,8 @@
                                                 {
                                                     var tcount = tfDict.TryGetValue(1, out var tc) ? tc : 0;
                                                     var fcount = tfDict.TryGetValue(0, out var fc) ? fc : 0;
-                                                    string tpercentage = (tcount / rowCount).ToString("P2");
-                                                    string fpercentage = (fcount / rowCount).ToString("P2");
+                                                    string tpercentage = rowCount == 0 ? "0.00%" : (tcount / rowCount).ToString("P2");
+                                                    string fpercentage = rowCount == 0 ? "0.00%" : (fcount / rowCount).ToString("P2");
                                                     <p>True: @tcount (@tpercentage)</p>
                                                     <p>False: @fcount (@fpercentage)</p>
                                                 }
@@ -114,7 +114,7 @@
                                                     foreach (var rating in Enumerable.Range(1, 10))
                                                     {
                                                         var rcount = rtDict.TryGetValue(rating, out var rc) ? rc : 0;
-                                                        string percentage = (rcount / rowCount).ToString("P2");
+                                                        string percentage = rowCount == 0 ? "0.00%" : (rcount / rowCount).ToString("P2");
                                                         <p>@rating: @rcount (@percentage)</p>
                                                     }
                                                 }

--- a/JwtIdentity.Client/Pages/Survey/Results/Filter.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Results/Filter.razor.cs
@@ -23,6 +23,8 @@ namespace JwtIdentity.Client.Pages.Survey.Results
 
         protected Dictionary<int, Dictionary<int, int>> OptionCounts { get; set; } = new();
 
+        protected int TotalRowCount { get; set; }
+
         protected override async Task OnInitializedAsync()
         {
             await LoadData();
@@ -90,6 +92,7 @@ namespace JwtIdentity.Client.Pages.Survey.Results
             SurveyRows = BuildSurveyRowsAsExpando(Survey.Questions, allAnswers).ToList();
 
             ComputeOptionCountsFromRows(SurveyRows);
+            TotalRowCount = SurveyRows.Count;
 
             columnsInitialized = true;
 
@@ -252,10 +255,11 @@ namespace JwtIdentity.Client.Pages.Survey.Results
         // call this whenever the grid renders or finishes an action
         private async Task RefreshCountsAsync()
         {
-            // Grab whatever rows are showing (empty if none)
-            var view = await Grid.GetCurrentViewRecordsAsync()
-                       ?? Enumerable.Empty<ExpandoObject>();
+            // Get all records that match the current filter (ignoring paging)
+            var data = await Grid.GetFilteredRecordsAsync();
+            var view = data as IEnumerable<ExpandoObject> ?? Enumerable.Empty<ExpandoObject>();
 
+            TotalRowCount = view.Count();
             ComputeOptionCountsFromRows(view);
             StateHasChanged();
         }


### PR DESCRIPTION
## Summary
- ensure Filter grid aggregates use all filtered rows instead of just the current page
- show row counts from total filtered data in aggregate footer

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c61419a494832aae61bcc1b7c1ac46