### PR TITLE
Always show questions panel and reintroduce regenerate demo

### DIFF
--- a/JwtIdentity.Client/Pages/Common/DragAndDrop.razor
+++ b/JwtIdentity.Client/Pages/Common/DragAndDrop.razor
@@ -6,13 +6,13 @@
     <div style="height: 10px; background-color: #007bff; width: 100%;"></div>
 }
 
-<div draggable="true"
+<div draggable="@(!Disabled)"
      @ondragstart="@((e) => OnDragStart(e, Items.IndexOf(Item)))"
      @ondragover="@((e) => OnDragOver(e, Items.IndexOf(Item)))"
      @ondrop="@((e) => OnDrop(e, Items.IndexOf(Item)))"
      @ondragleave="OnDragLeave"
      @ondragover:preventDefault="true"
-     @ondrop:preventDefault="true">     
+     @ondrop:preventDefault="true">
     @ChildContent
 </div>
 

--- a/JwtIdentity.Client/Pages/Common/DragAndDrop.razor.cs
+++ b/JwtIdentity.Client/Pages/Common/DragAndDrop.razor.cs
@@ -16,11 +16,15 @@ namespace JwtIdentity.Client.Pages.Common
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
+        [Parameter]
+        public bool Disabled { get; set; }
+
         protected int DragIndex { get; set; } = -1;
 
         protected int DragOverIndex { get; set; } = -1;
         protected async Task OnDragStart(DragEventArgs e, int index)
         {
+            if (Disabled) return;
             DragOverIndex = -1;
 
             if (index == -1)
@@ -37,6 +41,7 @@ namespace JwtIdentity.Client.Pages.Common
 
         protected async Task OnDragOver(DragEventArgs e, int index)
         {
+            if (Disabled) return;
             DragIndex = await LocalStorage.GetItemAsync<int>("DragIndex");
 
             if (DragIndex != -1 && index != -1)
@@ -52,12 +57,14 @@ namespace JwtIdentity.Client.Pages.Common
 
         protected void OnDragLeave(DragEventArgs e)
         {
+            if (Disabled) return;
             // Reset the drag-over index so previous lines disappear
             DragOverIndex = -1;
         }
 
         protected async Task OnDrop(DragEventArgs e, int index)
         {
+            if (Disabled) return;
             DragOverIndex = -1;
 
             DragIndex = await LocalStorage.GetItemAsync<int>("DragIndex");

--- a/JwtIdentity.Client/Pages/Survey/EditSurvey.razor
+++ b/JwtIdentity.Client/Pages/Survey/EditSurvey.razor
@@ -30,9 +30,19 @@
     <MudAlert Severity="Severity.Warning" Class="mb-2">
         <MudText Typo="Typo.body2">Please review the AI generated questions and answers. You may regenerate up to 2 times.</MudText>
         <MudStack Row="true" Spacing="1" Class="mt-2">
-            <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="RegenerateQuestions" Disabled="@(Survey.AiRetryCount >= 2)">Regenerate Questions</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="AcceptQuestions">Accept Questions</MudButton>
+            <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 10 })" IsButton="true">
+                <MudButton Id="RegenerateQuestionsBtn" Variant="Variant.Filled" Color="Color.Secondary" OnClick="RegenerateQuestions" Disabled="@(Survey.AiRetryCount >= 2)">Regenerate Questions</MudButton>
+            </DemoBorder>
+            <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 11 })" IsButton="true">
+                <MudButton Id="AcceptQuestionsBtn" Variant="Variant.Filled" Color="Color.Primary" OnClick="AcceptQuestions">Accept Questions</MudButton>
+            </DemoBorder>
         </MudStack>
+        <DemoPopup CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 10 })">
+            <MudText Typo="Typo.body2">Click here to regenerate the AI-generated questions.</MudText>
+        </DemoPopup>
+        <DemoPopup CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 11 })">
+            <MudText Typo="Typo.body2">Click here to accept the generated questions.</MudText>
+        </DemoPopup>
     </MudAlert>
 }
 
@@ -44,7 +54,10 @@
                 <MudExpansionPanel Id="QuestionsPanel" Expanded="@QuestionsPanelExpanded" ExpandedChanged="HandleQuestionsPanelExpanded">
                     <TitleContent>
                         <div class="mud-expand-panel-text">Survey Questions (Select a Question to Edit it)</div>
-                        <MudText Typo="Typo.caption" Align="Align.Center" Class="text-emphasis">Drag and Drop Questions to Reorder them, or click the Delete Icon to Remove a Question</MudText>
+                        @if (CanEditQuestions)
+                        {
+                            <MudText Typo="Typo.caption" Align="Align.Center" Class="text-emphasis">Drag and Drop Questions to Reorder them, or click the Delete Icon to Remove a Question</MudText>
+                        }
                     </TitleContent>
                     <ChildContent>
 
@@ -52,7 +65,7 @@
                             <MudList Id="QuestionList" T="QuestionViewModel" Dense="true" SelectedValue="SelectedQuestion" SelectionMode="MudBlazor.SelectionMode.ToggleSelection" SelectedValueChanged="QuestionSelected">
                                 @foreach (var question in Survey.Questions)
                                 {
-                                    <DragAndDrop TItem="QuestionViewModel" Items="Survey.Questions" Item="question" ItemsChanged="@(CanEditQuestions ? DroppedQuestion : null)">
+                                    <DragAndDrop TItem="QuestionViewModel" Items="Survey.Questions" Item="question" ItemsChanged="DroppedQuestion" Disabled="@(!CanEditQuestions)">
                                         <MudStack Class=".d-flex.flex-row.gap-3.ai-style-change-1" Row="true" AlignItems="AlignItems.Center">
                                             @if (CanEditQuestions)
                                             {

--- a/JwtIdentity.Client/Pages/Survey/EditSurvey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/EditSurvey.razor.cs
@@ -148,6 +148,8 @@ namespace JwtIdentity.Client.Pages.Survey
                 7 => "PresetChoices",
                 8 => "SaveQuestionBtn",
                 9 => "PublishSurveyBtn",
+                10 => "RegenerateQuestionsBtn",
+                11 => "AcceptQuestionsBtn",
                 _ => null
             };
 
@@ -682,7 +684,12 @@ namespace JwtIdentity.Client.Pages.Survey
             {
                 Survey = response;
                 SelectedQuestion = null;
+                QuestionsPanelExpanded = true;
                 _ = Snackbar.Add("Questions regenerated", MudBlazor.Severity.Success);
+                if (IsDemoUser && DemoStep == 10)
+                {
+                    DemoStep = 11;
+                }
             }
             else
             {
@@ -696,7 +703,12 @@ namespace JwtIdentity.Client.Pages.Survey
             if (response != null)
             {
                 Survey = response;
+                QuestionsPanelExpanded = true;
                 _ = Snackbar.Add("Questions accepted", MudBlazor.Severity.Success);
+                if (IsDemoUser && DemoStep == 11)
+                {
+                    DemoStep = 0;
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary
- Always render the survey questions panel, expanding it after regenerating or accepting AI questions
- Prevent drag-and-drop and deletion of questions until AI suggestions are approved or retries exhausted
- Restore demo guidance for regenerating and accepting questions

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c62ef0f2e0832abc042a932d73dd23