### PR TITLE
Fix regeneration of survey questions by cleaning up choice options

### DIFF
--- a/JwtIdentity/Controllers/SurveyController.cs
+++ b/JwtIdentity/Controllers/SurveyController.cs
@@ -586,6 +586,19 @@ namespace JwtIdentity.Controllers
                     return BadRequest("Retry limit reached");
                 }
 
+                var questionIds = survey.Questions.Select(q => q.Id).ToList();
+
+                if (questionIds.Any())
+                {
+                    var choiceOptions = await _context.ChoiceOptions
+                        .Where(co =>
+                            (co.MultipleChoiceQuestionId.HasValue && questionIds.Contains(co.MultipleChoiceQuestionId.Value)) ||
+                            (co.SelectAllThatApplyQuestionId.HasValue && questionIds.Contains(co.SelectAllThatApplyQuestionId.Value)))
+                        .ToListAsync();
+
+                    _context.ChoiceOptions.RemoveRange(choiceOptions);
+                }
+
                 _context.Questions.RemoveRange(survey.Questions);
                 await _context.SaveChangesAsync();
 


### PR DESCRIPTION
## Summary
- Remove dependent choice options before deleting survey questions to prevent FK violations
- Expand SurveyController tests to cover question regeneration and handle OpenAI calls generically

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c6399a4a78832aa1ee14d84beb2a95