### PR TITLE
Remove unnecessary demo step from survey editor

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/EditSurvey.razor
+++ b/JwtIdentity.Client/Pages/Survey/EditSurvey.razor
@@ -9,11 +9,11 @@
     <MudText Typo="Typo.h4">Edit Survey</MudText>
 
 
-    <DemoBorder Class="ms-auto mt-2" CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 11 })" IsButton="true">
+    <DemoBorder Class="ms-auto mt-2" CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 10 })" IsButton="true">
         <MudButton Id="PublishSurveyBtn" ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" OnClick="PublishSurvey" Disabled="@(Survey.Published)">Publish Survey</MudButton>
     </DemoBorder>
 
-    <DemoPopup CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 11 })">
+    <DemoPopup CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 10 })">
         <MudText Typo="Typo.body2">Now click the Publish Survey button to publish the survey.</MudText>
     </DemoPopup>
 </MudStack>
@@ -47,7 +47,7 @@
     <MudExpansionPanels MultiExpansion="true">
         @if (Survey?.Questions != null && Survey.Questions.Count > 0)
         {
-            <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 0, 2 })">
+            <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 0 })">
                 <MudExpansionPanel Id="QuestionsPanel" Expanded="@QuestionsPanelExpanded" ExpandedChanged="HandleQuestionsPanelExpanded">
                     <TitleContent>
                         <div class="mud-expand-panel-text">Survey Questions (Select a Question to Edit it)</div>
@@ -72,7 +72,7 @@
 
                                             @if (question.QuestionNumber == 1)
                                             {
-                                                <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 0, 4, 6, 8 })">
+                                                <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 0, 3, 5, 7 })">
                                                     <MudListItem Class="ai-style-change-3 ai-style-change-6" Text="@($"{question.QuestionNumber}. {question.Text}")" Value="@question" />
                                                 </DemoBorder>
                                             }
@@ -100,18 +100,15 @@
                 <MudText Typo="Typo.body2">AI can occasionally hallucinate. Review each generated question and its choices. Expand this panel and click question 1 to examine it.</MudText>
             </DemoPopup>
             <DemoPopup CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 2 })">
-                <MudText Typo="Typo.body2">Expand the Survey Questions Accordion by clicking it.</MudText>
-            </DemoPopup>
-            <DemoPopup CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 3 })">
                 <MudText Typo="Typo.body2">The questions can be reordered by dragging and dropping them.</MudText>
-                <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 3 })" IsButton="true">
+                <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 2 })" IsButton="true">
                     <MudButton OnClick="NextDemoStep" Variant="Variant.Filled" Color="Color.Success">Next</MudButton>
                 </DemoBorder>
             </DemoPopup>
-            <DemoPopup CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 4 })">
+            <DemoPopup CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 3 })">
                 <MudText Typo="Typo.body2">Click question number 1 to select it. The question text will turn blue when it is selected.</MudText>
             </DemoPopup>
-            <DemoPopup CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 6 })">
+            <DemoPopup CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 5 })">
                 <MudText Typo="Typo.body2">Click the selected question to deselect it.</MudText>
             </DemoPopup>
         }
@@ -123,8 +120,8 @@
             <MudExpansionPanel @ref="ManualQuestionPanel" @bind-Expanded="@ManualQuestionPanelExpanded" Text="Create Question Manually">
                 <MudPaper Class="p-2">
                     <MudStack Spacing="1">
-                        @{ bool purpleBorder = ShowDemoStep(5); }
-                        <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 5, 7 })" IsButton="@purpleBorder">
+                        @{ bool purpleBorder = ShowDemoStep(4); }
+                        <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 4, 6 })" IsButton="@purpleBorder">
                             <MudSelect Id="QuestionTypeSelect" Label="Select the Question Type"
                                        Value="@SelectedQuestionType"
                                        ValueChanged="@((string questionType) => HandleSelectedQuestionType(questionType))"
@@ -140,13 +137,13 @@
                             </MudSelect>
                         </DemoBorder>
                         <MudText Typo="Typo.h6" Class="mt-5">Create a @StringHelper.PascalCaseToWords(SelectedQuestionType) Question</MudText>
-                        <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 5, 8 })">
+                        <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 4, 7 })">
                             <MudTextField Id="Text" Label="Question Text" @bind-Value="QuestionText" Variant="Variant.Filled" Lines="1" MaxLines="5" AutoGrow="true" Immediate="true" Counter="500" MaxLength="500" />
                         </DemoBorder>
                     </MudStack>
 
                     <MudStack Row="true">
-                        <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 10 })" IsButton="true">
+                        <DemoBorder CurrentDemoStep="@DemoStep" StepsToShow="@(new List<int>() { 9 })" IsButton="true">
                             <MudButton Id="SaveQuestionBtn" ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" OnClick="AddQuestionToSurvey" Disabled="@AddQuestionToSurveyDisabled">Save Question</MudButton>
                         </DemoBorder>
                         <MudCheckBox T="bool" @bind-Value="IsRequired" Label="Is Required?" Color="Color.Primary" Disabled="@AddQuestionToSurveyDisabled" />

--- a/JwtIdentity.Client/Pages/Survey/EditSurvey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/EditSurvey.razor.cs
@@ -76,10 +76,10 @@ namespace JwtIdentity.Client.Pages.Survey
                         }
                     }
 
-                    if (IsDemoUser && DemoStep == 9 && value == "Yes No Partially")
-                    {
-                        DemoStep = 10;
-                    }
+                if (IsDemoUser && DemoStep == 8 && value == "Yes No Partially")
+                {
+                    DemoStep = 9;
+                }
                 }
             }
         }
@@ -144,13 +144,12 @@ namespace JwtIdentity.Client.Pages.Survey
             {
                 0 => "QuestionsPanel",
                 1 => "AcceptQuestionsBtn",
-                2 => "QuestionsPanel",
-                3 or 4 or 6 => "QuestionList",
-                5 or 8 => "Text",
-                7 => "QuestionTypeSelect",
-                9 => "PresetChoices",
-                10 => "SaveQuestionBtn",
-                11 => "PublishSurveyBtn",
+                2 or 3 or 5 => "QuestionList",
+                4 or 7 => "Text",
+                6 => "QuestionTypeSelect",
+                8 => "PresetChoices",
+                9 => "SaveQuestionBtn",
+                10 => "PublishSurveyBtn",
                 _ => null
             };
 
@@ -169,15 +168,15 @@ namespace JwtIdentity.Client.Pages.Survey
 
             switch (DemoStep)
             {
-                case 3:
-                    DemoStep = 4;
+                case 2:
+                    DemoStep = 3;
                     break;
-                case 5:
-                    DemoStep = 6;
+                case 4:
+                    DemoStep = 5;
                     break;
-                case 8:
+                case 7:
                     QuestionText = "Did the representative answer all of your questions?";
-                    DemoStep = 9;
+                    DemoStep = 8;
                     break;
             }
         }
@@ -375,9 +374,9 @@ namespace JwtIdentity.Client.Pages.Survey
             if (await UpdateSurvey())
             {
                 _ = Snackbar.Add("Question Added / Updated", MudBlazor.Severity.Success);
-                if (IsDemoUser && DemoStep == 10)
+                if (IsDemoUser && DemoStep == 9)
                 {
-                    DemoStep = 11;
+                    DemoStep = 10;
                 }
             }
             else
@@ -437,9 +436,9 @@ namespace JwtIdentity.Client.Pages.Survey
             MultipleChoiceQuestion = new MultipleChoiceQuestionViewModel();
             ResetQuestions = true;
 
-            if (IsDemoUser && DemoStep == 7 && questionType.Replace(" ", "") == Enum.GetName(QuestionType.MultipleChoice))
+            if (IsDemoUser && DemoStep == 6 && questionType.Replace(" ", "") == Enum.GetName(QuestionType.MultipleChoice))
             {
-                DemoStep = 8;
+                DemoStep = 7;
             }
         }
 
@@ -455,9 +454,9 @@ namespace JwtIdentity.Client.Pages.Survey
                 ManualQuestionPanelExpanded = true;
                 ExistingQuestionPanelExpanded = false;
 
-                if (IsDemoUser && DemoStep == 6)
+                if (IsDemoUser && DemoStep == 5)
                 {
-                    DemoStep = 7;
+                    DemoStep = 6;
                 }
 
                 return;
@@ -500,9 +499,9 @@ namespace JwtIdentity.Client.Pages.Survey
                 {
                     DemoStep = 1;
                 }
-                else if (DemoStep == 4 && input.QuestionNumber == 1)
+                else if (DemoStep == 3 && input.QuestionNumber == 1)
                 {
-                    DemoStep = 5;
+                    DemoStep = 4;
                 }
             }
         }
@@ -734,10 +733,6 @@ namespace JwtIdentity.Client.Pages.Survey
         protected void HandleQuestionsPanelExpanded(bool expanded)
         {
             QuestionsPanelExpanded = expanded;
-            if (IsDemoUser && DemoStep == 2 && expanded)
-            {
-                DemoStep = 3;
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- drop outdated demo step for expanding question panel and renumber remaining steps
- align code-behind navigation and handlers with new demo step sequence

## Testing
- `dotnet test` *(bUnit tests passed; server tests did not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e9c90578832ab583c3d3be3721db