### PR TITLE
Add Playwright E2E tests and logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,12 @@ When creating a new dialog, always use examples from Pages\Admin\Dialogs and Pag
 When creating a <MudList, always add the T parameter as T="string". See Home.razor for an example, or Documentation.razor
 
 The API project uses AutoMapper for mapping between entities and DTOs. The mapping profiles are located in the API project, and the AutoMapper configuration is done in Configurations/MapperConfig.cs.
-The controller endpoints that take a body take and return Viewmodels. The ViewModels are located in the Common project. 
+The controller endpoints that take a body take and return Viewmodels. The ViewModels are located in the Common project.
 The client project makes API calls using IApiService. Please review the methods in this file to understand how to make API calls. The IApiService is injected in the BlazorBase class, so you can use it directly in inherited Razor components and access API methods through dependency injection.
 When using Mudchip, do not add a Closable attribute. To make it closable, just define the OnClose event. See the example in EditUserDialog.razor.
 When creating a new Razor component, always create a code behind file with the same name as the Razor component file, plus Model. For example, if the Razor component file is named MyComponent.razor, the code behind file should be named MyComponentModel.razor.cs.
 app-dark.css is used for dark mode. It should only contain dark mode styles. Do not add any other styles to this file.
 app-light.css is used for light mode. It should only contain light mode styles. Do not add any other styles to this file.
 app.css is used for styles that are common to both dark mode and light mode. Do not add any dark mode or light mode specific styles to this file.
+
+Playwright end-to-end tests live in the JwtIdentity.PlaywrightTests project and use NUnit. Install browsers with `pwsh bin/Debug/net9.0/playwright.ps1 install` after the first build, and run the suite with `dotnet test JwtIdentity.PlaywrightTests`.

--- a/JwtIdentity.Client/Pages/Admin/PlaywrightLogs.razor
+++ b/JwtIdentity.Client/Pages/Admin/PlaywrightLogs.razor
@@ -1,0 +1,55 @@
+@page "/admin/playwright-logs"
+@attribute [Authorize(Roles = "Admin")]
+@inherits PlaywrightLogsModel
+@using SortDirection = Syncfusion.Blazor.Grids.SortDirection
+
+<PageTitle>Survey Shark - Playwright Test Logs</PageTitle>
+
+<MudText Typo="Typo.h4" Class="mb-4">Playwright Test Logs</MudText>
+
+@if (IsLoading)
+{
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+        <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+        <MudText>Loading Playwright test results...</MudText>
+    </MudStack>
+}
+else
+{
+    <MudPaper Class="pa-4">
+        <SfGrid TValue="PlaywrightLogViewModel"
+                DataSource="@PlaywrightLogs"
+                AllowPaging="true"
+                AllowSorting="true"
+                AllowFiltering="true"
+                AllowResizing="true"
+                GridLines="@GridSettings.GridLines"
+                TextWrapSettings="@GridSettings.TextWrapSettings">
+            <GridFilterSettings Type="Syncfusion.Blazor.Grids.FilterType.Excel"></GridFilterSettings>
+            <GridSortSettings>
+                <GridSortColumns>
+                    <GridSortColumn Field="ExecutedAt" Direction="SortDirection.Descending"></GridSortColumn>
+                </GridSortColumns>
+            </GridSortSettings>
+            <GridColumns>
+                <GridColumn Field="TestName" HeaderText="Test Name" Width="220" />
+                <GridColumn HeaderText="Status" Width="140">
+                    <Template Context="logContext">
+                        @if (logContext is PlaywrightLogViewModel log)
+                        {
+                            <MudChip T="string"
+                                     Size="MudBlazor.Size.Small"
+                                     Color="@GetStatusColor(log.Status)">
+                                @log.Status
+                            </MudChip>
+                        }
+                    </Template>
+                </GridColumn>
+                <GridColumn Field="ExecutedAt" HeaderText="Executed" Type="ColumnType.DateTime" Format="G" Width="200" />
+                <GridColumn Field="Browser" HeaderText="Browser" Width="120" />
+                <GridColumn Field="FailedElement" HeaderText="Element" Width="220" />
+                <GridColumn Field="ErrorMessage" HeaderText="Error" Width="320" />
+            </GridColumns>
+        </SfGrid>
+    </MudPaper>
+}

--- a/JwtIdentity.Client/Pages/Admin/PlaywrightLogs.razor.cs
+++ b/JwtIdentity.Client/Pages/Admin/PlaywrightLogs.razor.cs
@@ -1,0 +1,40 @@
+namespace JwtIdentity.Client.Pages.Admin
+{
+    public class PlaywrightLogsModel : BlazorBase
+    {
+        protected List<PlaywrightLogViewModel> PlaywrightLogs { get; set; } = new();
+        protected bool IsLoading { get; set; } = true;
+
+        protected override async Task OnInitializedAsync()
+        {
+            await LoadLogsAsync();
+        }
+
+        protected Color GetStatusColor(string status)
+        {
+            return status?.Equals("Passed", StringComparison.OrdinalIgnoreCase) == true
+                ? Color.Success
+                : Color.Error;
+        }
+
+        private async Task LoadLogsAsync()
+        {
+            try
+            {
+                IsLoading = true;
+                var logs = await ApiService.GetAllAsync<PlaywrightLogViewModel>(ApiEndpoints.PlaywrightLog);
+                PlaywrightLogs = logs?.OrderByDescending(log => log.ExecutedAt).ToList() ?? new List<PlaywrightLogViewModel>();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to load Playwright logs");
+                Snackbar.Add("Unable to load Playwright test results.", Severity.Error);
+            }
+            finally
+            {
+                IsLoading = false;
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+    }
+}

--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
@@ -27,6 +27,7 @@
                 <MudMenuItem Href="/admin/users">Manage Users</MudMenuItem>
                 <MudMenuItem Href="/admin/settings">Settings Management</MudMenuItem>
                 <MudMenuItem Href="/admin/logs">System Logs</MudMenuItem>
+                <MudMenuItem Href="/admin/playwright-logs">Playwright Logs</MudMenuItem>
                 <MudMenuItem Href="/ManageRolePermissions">Manage Permissions</MudMenuItem>
                 @if (CanUseHangfire)
                 {
@@ -90,6 +91,7 @@
                 <MudNavLink Href="/admin/users">Manage Users</MudNavLink>
                 <MudNavLink Href="/admin/settings">Settings Management</MudNavLink>
                 <MudNavLink Href="/admin/logs">System Logs</MudNavLink>
+                <MudNavLink Href="/admin/playwright-logs">Playwright Logs</MudNavLink>
                 <MudNavLink Href="/ManageRolePermissions">Manage Permissions</MudNavLink>
                 @if (CanUseHangfire)
                 {

--- a/JwtIdentity.Common/Helpers/ApiEndpoints.cs
+++ b/JwtIdentity.Common/Helpers/ApiEndpoints.cs
@@ -7,6 +7,7 @@
         public const string Auth = "api/auth";
         public const string ChoiceOption = "api/choiceoption";
         public const string Feedback = "api/feedback";
+        public const string PlaywrightLog = "api/playwrightlog";
         public const string Question = "api/question";
         public const string Settings = "api/settings";
         public const string Survey = "api/survey";

--- a/JwtIdentity.Common/ViewModels/PlaywrightLogViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/PlaywrightLogViewModel.cs
@@ -1,0 +1,13 @@
+namespace JwtIdentity.Common.ViewModels
+{
+    public class PlaywrightLogViewModel
+    {
+        public int Id { get; set; }
+        public string TestName { get; set; }
+        public string Status { get; set; }
+        public string? ErrorMessage { get; set; }
+        public string? FailedElement { get; set; }
+        public DateTime ExecutedAt { get; set; }
+        public string? Browser { get; set; }
+    }
+}

--- a/JwtIdentity.PlaywrightTests/Helpers/PlaywrightHelper.cs
+++ b/JwtIdentity.PlaywrightTests/Helpers/PlaywrightHelper.cs
@@ -1,0 +1,98 @@
+using System.Net.Http.Json;
+using JwtIdentity.Common.ViewModels;
+using Microsoft.Playwright;
+using Microsoft.Playwright.NUnit;
+using NUnit.Framework;
+
+namespace JwtIdentity.PlaywrightTests.Helpers
+{
+    public abstract class PlaywrightHelper : PageTest
+    {
+        private static readonly HttpClient HttpClient = CreateHttpClient();
+
+        protected virtual string BaseUrl => Environment.GetEnvironmentVariable("PLAYWRIGHT_BASE_URL") ?? "https://localhost:5001";
+        protected virtual string ApiEndpoint => $"{BaseUrl.TrimEnd('/')}/api/playwrightlog";
+        protected virtual string PlaywrightPassword => Environment.GetEnvironmentVariable("PLAYWRIGHT_PASSWORD") ?? "anonymous123";
+
+        protected string CurrentBrowserName => BrowserType?.Name ?? "chromium";
+
+        public override BrowserNewContextOptions ContextOptions()
+        {
+            var options = base.ContextOptions();
+            options.BaseURL = BaseUrl;
+            options.IgnoreHTTPSErrors = true;
+            return options;
+        }
+
+        protected async Task LoginAsync(string username, string? password = null)
+        {
+            password ??= PlaywrightPassword;
+            await Page.GotoAsync("/login");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.FillAsync("#username", username);
+            await Page.FillAsync("#password", password);
+            await Page.ClickAsync("button[type='submit']");
+        }
+
+        protected async Task LogoutAsync()
+        {
+            await Page.GotoAsync("/logout");
+            await Page.WaitForURLAsync("**/login");
+        }
+
+        protected async Task ExecuteWithLoggingAsync(string testName, string? targetSelector, Func<Task> testBody)
+        {
+            try
+            {
+                await testBody();
+                await LogAsync(new PlaywrightLogViewModel
+                {
+                    TestName = testName,
+                    Status = "Passed",
+                    ExecutedAt = DateTime.UtcNow,
+                    Browser = CurrentBrowserName
+                });
+            }
+            catch (Exception ex)
+            {
+                await LogAsync(new PlaywrightLogViewModel
+                {
+                    TestName = testName,
+                    Status = "Failed",
+                    ErrorMessage = ex.Message,
+                    FailedElement = targetSelector,
+                    ExecutedAt = DateTime.UtcNow,
+                    Browser = CurrentBrowserName
+                });
+
+                throw;
+            }
+        }
+
+        private async Task LogAsync(PlaywrightLogViewModel log)
+        {
+            try
+            {
+                var response = await HttpClient.PostAsJsonAsync(ApiEndpoint, log);
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception ex)
+            {
+                TestContext.Error.WriteLine($"Failed to log Playwright test result: {ex}");
+            }
+        }
+
+        private static HttpClient CreateHttpClient()
+        {
+            var handler = new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+            };
+
+            return new HttpClient(handler, disposeHandler: true)
+            {
+                Timeout = TimeSpan.FromSeconds(30)
+            };
+        }
+    }
+}

--- a/JwtIdentity.PlaywrightTests/JwtIdentity.PlaywrightTests.csproj
+++ b/JwtIdentity.PlaywrightTests/JwtIdentity.PlaywrightTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.46.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JwtIdentity.Common\JwtIdentity.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/JwtIdentity.PlaywrightTests/Tests/AuthTests.cs
+++ b/JwtIdentity.PlaywrightTests/Tests/AuthTests.cs
@@ -1,0 +1,28 @@
+using JwtIdentity.PlaywrightTests.Helpers;
+using NUnit.Framework;
+
+namespace JwtIdentity.PlaywrightTests.Tests
+{
+    [TestFixture]
+    public class AuthTests : PlaywrightHelper
+    {
+        [Test]
+        public async Task LoginTest_Succeeds()
+        {
+            const string logoutSelector = "a[href='logout']";
+
+            await ExecuteWithLoggingAsync(nameof(LoginTest_Succeeds), logoutSelector, async () =>
+            {
+                await LoginAsync("playwrightuser");
+
+                var logoutLink = Page.Locator(logoutSelector);
+                await Microsoft.Playwright.Assertions.Expect(logoutLink).ToBeVisibleAsync();
+
+                await logoutLink.ClickAsync();
+
+                var loginLink = Page.Locator("a[href='login']");
+                await Microsoft.Playwright.Assertions.Expect(loginLink).ToBeVisibleAsync();
+            });
+        }
+    }
+}

--- a/JwtIdentity.sln
+++ b/JwtIdentity.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		global.json = global.json
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JwtIdentity.PlaywrightTests", "JwtIdentity.PlaywrightTests\JwtIdentity.PlaywrightTests.csproj", "{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -90,6 +92,18 @@ Global
 		{39F02D5C-B7CC-4A43-ADD0-35A83C3A00B9}.Release|x64.Build.0 = Release|Any CPU
 		{39F02D5C-B7CC-4A43-ADD0-35A83C3A00B9}.Release|x86.ActiveCfg = Release|Any CPU
 		{39F02D5C-B7CC-4A43-ADD0-35A83C3A00B9}.Release|x86.Build.0 = Release|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Debug|x64.Build.0 = Debug|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Debug|x86.Build.0 = Debug|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Release|x64.ActiveCfg = Release|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Release|x64.Build.0 = Release|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Release|x86.ActiveCfg = Release|Any CPU
+		{ADAB70F6-D073-4B82-9BAB-6EE7FD3B8699}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/JwtIdentity/Configurations/MapperConfig.cs
+++ b/JwtIdentity/Configurations/MapperConfig.cs
@@ -94,6 +94,8 @@
                 .ForMember(dest => dest.NumberOfResponses, opt => opt.Ignore()); // Don't map this property from Survey model
             
             _ = CreateMap<SurveyViewModel, Survey>();
+
+            _ = CreateMap<PlaywrightLog, PlaywrightLogViewModel>().ReverseMap();
         }
     }
 }

--- a/JwtIdentity/Controllers/PlaywrightLogController.cs
+++ b/JwtIdentity/Controllers/PlaywrightLogController.cs
@@ -1,0 +1,102 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace JwtIdentity.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PlaywrightLogController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly IMapper _mapper;
+        private readonly ILogger<PlaywrightLogController> _logger;
+
+        public PlaywrightLogController(
+            ApplicationDbContext context,
+            IMapper mapper,
+            ILogger<PlaywrightLogController> logger)
+        {
+            _context = context;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        [Authorize(Roles = "Admin")]
+        public async Task<ActionResult<IEnumerable<PlaywrightLogViewModel>>> GetPlaywrightLogs()
+        {
+            try
+            {
+                var logs = await _context.PlaywrightLogs
+                    .OrderByDescending(log => log.ExecutedAt)
+                    .ToListAsync();
+
+                return Ok(_mapper.Map<IEnumerable<PlaywrightLogViewModel>>(logs));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve Playwright logs");
+                return StatusCode(500, "An error occurred while retrieving Playwright logs.");
+            }
+        }
+
+        [HttpGet("{id}")]
+        [Authorize(Roles = "Admin")]
+        public async Task<ActionResult<PlaywrightLogViewModel>> GetPlaywrightLog(int id)
+        {
+            try
+            {
+                var log = await _context.PlaywrightLogs.FindAsync(id);
+
+                if (log == null)
+                {
+                    return NotFound();
+                }
+
+                return Ok(_mapper.Map<PlaywrightLogViewModel>(log));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve Playwright log {LogId}", id);
+                return StatusCode(500, "An error occurred while retrieving the Playwright log.");
+            }
+        }
+
+        [HttpPost]
+        [AllowAnonymous]
+        public async Task<ActionResult<PlaywrightLogViewModel>> CreatePlaywrightLog(PlaywrightLogViewModel logViewModel)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(logViewModel.TestName))
+                {
+                    return BadRequest("Test name is required.");
+                }
+
+                if (string.IsNullOrWhiteSpace(logViewModel.Status))
+                {
+                    logViewModel.Status = "Unknown";
+                }
+
+                if (logViewModel.ExecutedAt == default)
+                {
+                    logViewModel.ExecutedAt = DateTime.UtcNow;
+                }
+
+                var log = _mapper.Map<PlaywrightLog>(logViewModel);
+
+                _context.PlaywrightLogs.Add(log);
+                await _context.SaveChangesAsync();
+
+                var createdLog = _mapper.Map<PlaywrightLogViewModel>(log);
+                return CreatedAtAction(nameof(GetPlaywrightLog), new { id = createdLog.Id }, createdLog);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create Playwright log entry for test {TestName}", logViewModel.TestName);
+                return StatusCode(500, "An error occurred while recording the Playwright log.");
+            }
+        }
+    }
+}

--- a/JwtIdentity/Data/ApplicationDbContext.cs
+++ b/JwtIdentity/Data/ApplicationDbContext.cs
@@ -29,6 +29,7 @@ namespace JwtIdentity.Data
         // You can add a DbSet if you like:
         public DbSet<RoleClaim> RoleClaims { get; set; }
         public DbSet<LogEntry> LogEntries { get; set; }
+        public DbSet<PlaywrightLog> PlaywrightLogs { get; set; }
         public DbSet<Survey> Surveys { get; set; }
         public DbSet<Question> Questions { get; set; }
         public DbSet<Answer> Answers { get; set; }
@@ -100,6 +101,32 @@ namespace JwtIdentity.Data
                 },
                 new ApplicationUser
                 {
+                    Id = 5,
+                    UserName = "playwrightuser",
+                    NormalizedUserName = "PLAYWRIGHTUSER",
+                    Email = "playwrightuser@example.com",
+                    NormalizedEmail = "PLAYWRIGHTUSER@EXAMPLE.COM",
+                    EmailConfirmed = true,
+                    PasswordHash = "AQAAAAIAAYagAAAAEDaaeD+y1I6b06Mfnm/tKqk8uIC+IIyCC5XMjODRg0PAJuxDcmPh6iihBkSLhMoyJQ==",
+                    ConcurrencyStamp = "9b8d1f30-4bd3-4f1f-b83b-5677f49a434e",
+                    SecurityStamp = string.Empty,
+                    Theme = "light"
+                },
+                new ApplicationUser
+                {
+                    Id = 6,
+                    UserName = "playwrightadmin",
+                    NormalizedUserName = "PLAYWRIGHTADMIN",
+                    Email = "playwrightadmin@example.com",
+                    NormalizedEmail = "PLAYWRIGHTADMIN@EXAMPLE.COM",
+                    EmailConfirmed = true,
+                    PasswordHash = "AQAAAAIAAYagAAAAEDaaeD+y1I6b06Mfnm/tKqk8uIC+IIyCC5XMjODRg0PAJuxDcmPh6iihBkSLhMoyJQ==",
+                    ConcurrencyStamp = "c5ab9ce3-a09f-4d77-b332-98cc44396f44",
+                    SecurityStamp = string.Empty,
+                    Theme = "dark"
+                },
+                new ApplicationUser
+                {
                     Id = -1,
                     UserName = "DemoUser@surveyshark.site",
                     NormalizedUserName = "DEMOUSER@SURVEYSHARK.SITE",
@@ -118,8 +145,21 @@ namespace JwtIdentity.Data
                 new IdentityUserRole<int> { UserId = 1, RoleId = 1 }, // Admin
                 new IdentityUserRole<int> { UserId = 2, RoleId = 2 },  // User
                 new IdentityUserRole<int> { UserId = 3, RoleId = 4 },  // AnonymousUser
+                new IdentityUserRole<int> { UserId = 5, RoleId = 2 },  // PlaywrightUser
+                new IdentityUserRole<int> { UserId = 6, RoleId = 1 },  // PlaywrightAdmin
                 new IdentityUserRole<int> { UserId = -1, RoleId = 2 }  // DemoUser
             );
+
+            _ = builder.Entity<PlaywrightLog>()
+                .Property(p => p.TestName)
+                .HasMaxLength(256);
+
+            _ = builder.Entity<PlaywrightLog>()
+                .Property(p => p.Status)
+                .HasMaxLength(64);
+
+            _ = builder.Entity<PlaywrightLog>()
+                .HasIndex(p => p.ExecutedAt);
 
             var type = typeof(Permissions);
             List<string> AllPermissions;

--- a/JwtIdentity/Migrations/20250916002650_AddPlaywrightLogging.Designer.cs
+++ b/JwtIdentity/Migrations/20250916002650_AddPlaywrightLogging.Designer.cs
@@ -4,6 +4,7 @@ using JwtIdentity.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace JwtIdentity.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250916002650_AddPlaywrightLogging")]
+    partial class AddPlaywrightLogging
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/JwtIdentity/Migrations/20250916002650_AddPlaywrightLogging.cs
+++ b/JwtIdentity/Migrations/20250916002650_AddPlaywrightLogging.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace JwtIdentity.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlaywrightLogging : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PlaywrightLogs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    TestName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: true),
+                    ErrorMessage = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    FailedElement = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ExecutedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Browser = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlaywrightLogs", x => x.Id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "AspNetUsers",
+                columns: new[] { "Id", "AccessFailedCount", "ConcurrencyStamp", "CreatedDate", "Email", "EmailConfirmed", "LockoutEnabled", "LockoutEnd", "NormalizedEmail", "NormalizedUserName", "PasswordHash", "PhoneNumber", "PhoneNumberConfirmed", "SecurityStamp", "Theme", "TwoFactorEnabled", "UpdatedDate", "UserName" },
+                values: new object[,]
+                {
+                    { 5, 0, "9b8d1f30-4bd3-4f1f-b83b-5677f49a434e", new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), "playwrightuser@example.com", true, false, null, "PLAYWRIGHTUSER@EXAMPLE.COM", "PLAYWRIGHTUSER", "AQAAAAIAAYagAAAAEDaaeD+y1I6b06Mfnm/tKqk8uIC+IIyCC5XMjODRg0PAJuxDcmPh6iihBkSLhMoyJQ==", null, false, "", "light", false, new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), "playwrightuser" },
+                    { 6, 0, "c5ab9ce3-a09f-4d77-b332-98cc44396f44", new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), "playwrightadmin@example.com", true, false, null, "PLAYWRIGHTADMIN@EXAMPLE.COM", "PLAYWRIGHTADMIN", "AQAAAAIAAYagAAAAEDaaeD+y1I6b06Mfnm/tKqk8uIC+IIyCC5XMjODRg0PAJuxDcmPh6iihBkSLhMoyJQ==", null, false, "", "dark", false, new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), "playwrightadmin" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "AspNetUserRoles",
+                columns: new[] { "RoleId", "UserId" },
+                values: new object[,]
+                {
+                    { 2, 5 },
+                    { 1, 6 }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlaywrightLogs_ExecutedAt",
+                table: "PlaywrightLogs",
+                column: "ExecutedAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlaywrightLogs");
+
+            migrationBuilder.DeleteData(
+                table: "AspNetUserRoles",
+                keyColumns: new[] { "RoleId", "UserId" },
+                keyValues: new object[] { 2, 5 });
+
+            migrationBuilder.DeleteData(
+                table: "AspNetUserRoles",
+                keyColumns: new[] { "RoleId", "UserId" },
+                keyValues: new object[] { 1, 6 });
+
+            migrationBuilder.DeleteData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: 5);
+
+            migrationBuilder.DeleteData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: 6);
+        }
+    }
+}

--- a/JwtIdentity/Models/PlaywrightLog.cs
+++ b/JwtIdentity/Models/PlaywrightLog.cs
@@ -1,0 +1,13 @@
+namespace JwtIdentity.Models
+{
+    public class PlaywrightLog
+    {
+        public int Id { get; set; }
+        public string TestName { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public string? ErrorMessage { get; set; }
+        public string? FailedElement { get; set; }
+        public DateTime ExecutedAt { get; set; }
+        public string? Browser { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Playwright test project with a shared helper that signs in and records pass or fail details
- seed dedicated Playwright users, introduce a PlaywrightLog entity with API endpoints, and create the supporting EF migration
- surface the new logs in an admin Syncfusion grid, link it in the navigation, and document how to run the Playwright suite in AGENTS

## Testing
- `dotnet test JwtIdentity.Tests/JwtIdentity.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c8ab07634c832aaad7a75964353486