### PR TITLE
Configure Playwright headed mode via appsettings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,5 @@ FodyWeavers.xsd
 /JwtIdentity.Client/wwwroot/appsettings.Development.json
 /SeleniumTests
 # /API.ps1
+
+/JwtIdentity.PlaywrightTests/appsettings.Development.json

--- a/JwtIdentity.PlaywrightTests/Helpers/PlaywrightHelper.cs
+++ b/JwtIdentity.PlaywrightTests/Helpers/PlaywrightHelper.cs
@@ -9,6 +9,25 @@ namespace JwtIdentity.PlaywrightTests.Helpers
     public abstract class PlaywrightHelper : PageTest
     {
         private static readonly HttpClient HttpClient = CreateHttpClient();
+        private string? _originalHeadedValue;
+
+        [OneTimeSetUp]
+        public void ConfigurePlaywrightExecutionMode()
+        {
+            _originalHeadedValue = Environment.GetEnvironmentVariable("HEADED");
+
+            var settings = PlaywrightTestConfiguration.Settings;
+            var headedValue = settings.Headless ? "0" : "1";
+            Environment.SetEnvironmentVariable("HEADED", headedValue);
+
+            TestContext.Progress.WriteLine($"Playwright headless mode: {settings.Headless}");
+        }
+
+        [OneTimeTearDown]
+        public void RestorePlaywrightExecutionMode()
+        {
+            Environment.SetEnvironmentVariable("HEADED", _originalHeadedValue);
+        }
 
         protected virtual string BaseUrl => Environment.GetEnvironmentVariable("PLAYWRIGHT_BASE_URL") ?? "https://localhost:5001";
         protected virtual string ApiEndpoint => $"{BaseUrl.TrimEnd('/')}/api/playwrightlog";

--- a/JwtIdentity.PlaywrightTests/Helpers/PlaywrightTestConfiguration.cs
+++ b/JwtIdentity.PlaywrightTests/Helpers/PlaywrightTestConfiguration.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Configuration;
+
+namespace JwtIdentity.PlaywrightTests.Helpers;
+
+public sealed class PlaywrightTestSettings
+{
+    public bool Headless { get; set; } = true;
+}
+
+public static class PlaywrightTestConfiguration
+{
+    private static readonly Lazy<PlaywrightTestSettings> SettingsLazy = new(LoadSettings);
+
+    public static PlaywrightTestSettings Settings => SettingsLazy.Value;
+
+    private static PlaywrightTestSettings LoadSettings()
+    {
+        var environment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")
+                          ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+                          ?? "Production";
+
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+            .AddJsonFile($"appsettings.{environment}.json", optional: true, reloadOnChange: false)
+            .Build();
+
+        var settings = configuration.GetSection("Playwright").Get<PlaywrightTestSettings>();
+        return settings ?? new PlaywrightTestSettings();
+    }
+}

--- a/JwtIdentity.PlaywrightTests/JwtIdentity.PlaywrightTests.csproj
+++ b/JwtIdentity.PlaywrightTests/JwtIdentity.PlaywrightTests.csproj
@@ -9,11 +9,19 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.46.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\JwtIdentity.Common\JwtIdentity.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="appsettings.Development.json" CopyToOutputDirectory="PreserveNewest" Condition="Exists('appsettings.Development.json')" />
   </ItemGroup>
 </Project>

--- a/JwtIdentity.PlaywrightTests/appsettings.Development.json
+++ b/JwtIdentity.PlaywrightTests/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+  "Playwright": {
+    "Headless": false
+  }
+}

--- a/JwtIdentity.PlaywrightTests/appsettings.json
+++ b/JwtIdentity.PlaywrightTests/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "Playwright": {
+    "Headless": true
+  }
+}


### PR DESCRIPTION
## Summary
- load Playwright test settings from appsettings files so the HEADED environment variable is driven by configuration
- add default and development appsettings files plus package references for JSON configuration
- copy the configuration files during builds and ignore the development variant in source control

## Testing
- dotnet build JwtIdentity.PlaywrightTests/JwtIdentity.PlaywrightTests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68c8b82d8a98832aa90dcf07b1d90118