### PR TITLE
Fix Playwright test password

### DIFF
--- a/JwtIdentity.PlaywrightTests/Helpers/PlaywrightHelper.cs
+++ b/JwtIdentity.PlaywrightTests/Helpers/PlaywrightHelper.cs
@@ -31,7 +31,7 @@ namespace JwtIdentity.PlaywrightTests.Helpers
 
         protected virtual string BaseUrl => Environment.GetEnvironmentVariable("PLAYWRIGHT_BASE_URL") ?? "https://localhost:5001";
         protected virtual string ApiEndpoint => $"{BaseUrl.TrimEnd('/')}/api/playwrightlog";
-        protected virtual string PlaywrightPassword => Environment.GetEnvironmentVariable("PLAYWRIGHT_PASSWORD") ?? "UserPassword_123";
+        protected virtual string PlaywrightPassword => Environment.GetEnvironmentVariable("PLAYWRIGHT_PASSWORD") ?? "UserPassword123";
 
         protected string CurrentBrowserName => BrowserType?.Name ?? "chromium";
 


### PR DESCRIPTION
## Summary
- update the Playwright test helper to fall back to the seeded user password so login succeeds

## Testing
- dotnet test JwtIdentity.PlaywrightTests *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8cb3eacd4832a801b5df31a8094c6