### PR TITLE
Fix Playwright logout locator strict mode violation

### DIFF
--- a/JwtIdentity.PlaywrightTests/Tests/AuthTests.cs
+++ b/JwtIdentity.PlaywrightTests/Tests/AuthTests.cs
@@ -1,4 +1,5 @@
 using JwtIdentity.PlaywrightTests.Helpers;
+using Microsoft.Playwright;
 using NUnit.Framework;
 
 namespace JwtIdentity.PlaywrightTests.Tests
@@ -9,13 +10,15 @@ namespace JwtIdentity.PlaywrightTests.Tests
         [Test]
         public async Task LoginTest_Succeeds()
         {
-            const string logoutSelector = "a[href='logout']";
+            const string logoutSelectorDescription = "Toolbar logout link";
 
-            await ExecuteWithLoggingAsync(nameof(LoginTest_Succeeds), logoutSelector, async () =>
+            await ExecuteWithLoggingAsync(nameof(LoginTest_Succeeds), logoutSelectorDescription, async () =>
             {
                 await LoginAsync("playwrightuser@example.com");
 
-                var logoutLink = Page.Locator(logoutSelector);
+                var logoutLink = Page
+                    .GetByRole(AriaRole.Toolbar)
+                    .GetByRole(AriaRole.Link, new() { Name = "Logout" });
                 await Microsoft.Playwright.Assertions.Expect(logoutLink).ToBeVisibleAsync();
 
                 await logoutLink.ClickAsync();


### PR DESCRIPTION
## Summary
- update the Playwright login test to target the toolbar logout link so the locator resolves to a single element

## Testing
- dotnet test JwtIdentity.PlaywrightTests *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ce3b36b0832a858b538ae2e0d79e