### PR TITLE
Add demo page YouTube embed from app settings

### DIFF
--- a/JwtIdentity.Client/Pages/Demo/DemoLanding.razor
+++ b/JwtIdentity.Client/Pages/Demo/DemoLanding.razor
@@ -108,4 +108,14 @@
             </MudTimelineItem>
         </MudTimeline>
     </MudPaper>
+
+    @if (HasYoutubeEmbed)
+    {
+        <MudPaper Elevation="1" Class="pa-5 mt-6">
+            <MudText Typo="Typo.h5" Class="mb-3">Watch the Survey Shark Demo</MudText>
+            <div class="d-flex justify-center">
+                @((MarkupString)YoutubeEmbedCode)
+            </div>
+        </MudPaper>
+    }
 </MudContainer>

--- a/JwtIdentity.Client/Pages/Demo/DemoLanding.razor.cs
+++ b/JwtIdentity.Client/Pages/Demo/DemoLanding.razor.cs
@@ -4,6 +4,17 @@ namespace JwtIdentity.Client.Pages.Demo
     {
         protected bool IsStartingDemo { get; set; }
 
+        protected AppSettings AppSettings { get; set; } = new();
+
+        protected bool HasYoutubeEmbed => !string.IsNullOrWhiteSpace(AppSettings.Youtube?.HomePageCode);
+
+        protected string YoutubeEmbedCode => AppSettings.Youtube?.HomePageCode ?? string.Empty;
+
+        protected override async Task OnInitializedAsync()
+        {
+            AppSettings = await ApiService.GetPublicAsync<AppSettings>("/api/appsettings");
+        }
+
         protected async Task BeginDemo()
         {
             if (IsStartingDemo)


### PR DESCRIPTION
## Summary
- load demo landing settings from the app settings API so the page can access the configured YouTube embed
- render the configured YouTube video at the bottom of the demo page when an embed code is provided

## Testing
- dotnet build JwtIdentity.sln *(fails: `dotnet` command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cee21e1df4832a9c23ee81fdb5d05c