### PR TITLE
Embed demo YouTube video directly

### DIFF
--- a/JwtIdentity.Client/Pages/Demo/DemoLanding.razor
+++ b/JwtIdentity.Client/Pages/Demo/DemoLanding.razor
@@ -108,4 +108,18 @@
             </MudTimelineItem>
         </MudTimeline>
     </MudPaper>
+
+    <MudPaper Elevation="1" Class="pa-5 mt-6">
+        <MudText Typo="Typo.h5" Class="mb-3">Watch the Survey Shark Demo</MudText>
+        <MudAspectRatio Ratio="16 / 9">
+            <iframe width="100%"
+                    height="100%"
+                    src="https://www.youtube.com/embed/v0XqRue1aAM"
+                    title="Survey Shark Demo Video"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    allowfullscreen>
+            </iframe>
+        </MudAspectRatio>
+    </MudPaper>
 </MudContainer>


### PR DESCRIPTION
## Summary
- replace the configuration-driven embed with a fixed iframe that plays the Survey Shark demo video on the demo page

## Testing
- dotnet build JwtIdentity.sln *(fails: `dotnet` command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cee21e1df4832a9c23ee81fdb5d05c