### PR TITLE
Display docs search results inline

### DIFF
--- a/JwtIdentity.Client/Pages/Docs/_DocsLayout.razor
+++ b/JwtIdentity.Client/Pages/Docs/_DocsLayout.razor
@@ -38,30 +38,9 @@
                                           OnClearButtonClick="@(EventCallback.Factory.Create(this, CloseSearch))" />
                             @if (ShowSearchResults)
                             {
-                                <MudPaper Class="docs-search-popover">
-                                    @if (IsSearching)
-                                    {
-                                        <div class="docs-search-status">Searching…</div>
-                                    }
-                                    else if (SearchResults.Count == 0)
-                                    {
-                                        <div class="docs-search-status">No results yet.</div>
-                                    }
-                                    else
-                                    {
-                                        @foreach (var hit in SearchResults)
-                                        {
-                                            <a href="@hit.url" @onclick="() => NavigateToResult(hit.url)" class="docs-search-hit">
-                                                <span class="section">@hit.section</span>
-                                                <strong>@hit.title</strong>
-                                                @if (!string.IsNullOrEmpty(hit.snippet))
-                                                {
-                                                    <div class="snippet">@((MarkupString)hit.snippet)</div>
-                                                }
-                                            </a>
-                                        }
-                                    }
-                                </MudPaper>
+                                <div class="docs-search-results docs-search-results-appbar hidden md:block">
+                                    @RenderSearchResults()
+                                </div>
                             }
                         </div>
                     </MudAppBar>
@@ -122,6 +101,13 @@
                                                       Clearable="true"
                                                       OnClearButtonClick="@(EventCallback.Factory.Create(this, CloseSearch))" />
                                     </div>
+
+                                    @if (ShowSearchResults)
+                                    {
+                                        <div class="docs-search-results docs-search-results-content md:hidden">
+                                            @RenderSearchResults()
+                                        </div>
+                                    }
 
                                     @if (TocItems.Count > 0)
                                     {

--- a/JwtIdentity.Client/Pages/Docs/_DocsLayout.razor.cs
+++ b/JwtIdentity.Client/Pages/Docs/_DocsLayout.razor.cs
@@ -52,6 +52,56 @@ namespace JwtIdentity.Client.Pages.Docs
 
         protected bool ShowSearchResults => SearchQuery.Trim().Length >= 2;
 
+        protected RenderFragment RenderSearchResults() => builder =>
+        {
+            var sequence = 0;
+
+            if (IsSearching)
+            {
+                builder.OpenElement(sequence++, "div");
+                builder.AddAttribute(sequence++, "class", "docs-search-status");
+                builder.AddContent(sequence++, "Searching…");
+                builder.CloseElement();
+                return;
+            }
+
+            if (SearchResults.Count == 0)
+            {
+                builder.OpenElement(sequence++, "div");
+                builder.AddAttribute(sequence++, "class", "docs-search-status");
+                builder.AddContent(sequence++, "No results yet.");
+                builder.CloseElement();
+                return;
+            }
+
+            foreach (var hit in SearchResults)
+            {
+                builder.OpenElement(sequence++, "a");
+                builder.AddAttribute(sequence++, "href", hit.url);
+                builder.AddAttribute(sequence++, "class", "docs-search-hit");
+                builder.AddAttribute(sequence++, "onclick", EventCallback.Factory.Create(this, () => NavigateToResult(hit.url)));
+
+                builder.OpenElement(sequence++, "span");
+                builder.AddAttribute(sequence++, "class", "section");
+                builder.AddContent(sequence++, hit.section);
+                builder.CloseElement();
+
+                builder.OpenElement(sequence++, "strong");
+                builder.AddContent(sequence++, hit.title);
+                builder.CloseElement();
+
+                if (!string.IsNullOrEmpty(hit.snippet))
+                {
+                    builder.OpenElement(sequence++, "div");
+                    builder.AddAttribute(sequence++, "class", "snippet");
+                    builder.AddMarkupContent(sequence++, hit.snippet);
+                    builder.CloseElement();
+                }
+
+                builder.CloseElement();
+            }
+        };
+
         protected void OpenSidebar()
         {
             SidebarOpen = true;

--- a/JwtIdentity/wwwroot/css/app.css
+++ b/JwtIdentity/wwwroot/css/app.css
@@ -733,17 +733,29 @@ td.e-summarycell.e-templatecell.e-leftalign {
     width: min(30rem, 100%);
 }
 
-.docs-search-popover {
-    position: absolute;
-    top: calc(100% + 0.5rem);
-    right: 0;
-    width: min(34rem, 90vw);
-    max-height: 60vh;
-    overflow-y: auto;
-    padding: 0.5rem;
+.docs-search-results {
+    margin-top: 0.75rem;
+    padding: 0.65rem 0.75rem;
     border-radius: 0.75rem;
-    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.18);
     background-color: var(--mud-palette-surface, #fff);
+    border: 1px solid rgba(96, 125, 139, 0.22);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+    height: 18rem;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.docs-search-results-appbar {
+    width: min(34rem, 90vw);
+}
+
+.docs-search-results-content {
+    width: 100%;
+    box-shadow: none;
+    border-color: rgba(96, 125, 139, 0.15);
+    margin-bottom: 1.25rem;
 }
 
 .docs-search-hit {


### PR DESCRIPTION
## Summary
- render documentation search results inline below the search inputs instead of a popover
- share rendering logic through a helper to keep both desktop and mobile views consistent
- style the inline search results container with a fixed-height, scrollable panel

## Testing
- ~/.dotnet/dotnet build JwtIdentity.sln

------
https://chatgpt.com/codex/tasks/task_e_68cf44887f3c832a892946bb9b79fc64