### PR TITLE
Prevent docs search field from losing focus while querying

### DIFF
--- a/JwtIdentity.Client/Pages/Docs/_DocsLayout.razor
+++ b/JwtIdentity.Client/Pages/Docs/_DocsLayout.razor
@@ -33,7 +33,6 @@
                                           AdornmentIcon="@Icons.Material.Filled.Search"
                                           Class="hidden md:block docs-search-input"
                                           Immediate="true"
-                                          Disabled="@IsSearching"
                                           Clearable="true"
                                           OnClearButtonClick="@(EventCallback.Factory.Create(this, CloseSearch))" />
                             @if (ShowSearchResults)
@@ -97,7 +96,6 @@
                                                       Adornment="Adornment.Start"
                                                       AdornmentIcon="@Icons.Material.Filled.Search"
                                                       Immediate="true"
-                                                      Disabled="@IsSearching"
                                                       Clearable="true"
                                                       OnClearButtonClick="@(EventCallback.Factory.Create(this, CloseSearch))" />
                                     </div>


### PR DESCRIPTION
## Summary
- keep the documentation search inputs enabled while background search requests are running
- prevent Blazor from removing focus from the textbox after each character is entered

## Testing
- `dotnet build JwtIdentity.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf47c30750832aab925ef2e06167a3