### PR TITLE
Ensure docs layout scrolls to top on navigation

### DIFF
--- a/JwtIdentity/wwwroot/js/app.js
+++ b/JwtIdentity/wwwroot/js/app.js
@@ -55,3 +55,14 @@ export function scrollToElement(elementId) {
         scrollContainer.scrollTo({ top: destination, behavior: 'smooth' });
     }
 }
+
+export function scrollToTop() {
+    const scrollContainer = document.querySelector('.main-content');
+
+    if (scrollContainer && typeof scrollContainer.scrollTo === 'function') {
+        scrollContainer.scrollTo({ top: 0, behavior: 'auto' });
+        return;
+    }
+
+    window.scrollTo({ top: 0, behavior: 'auto' });
+}


### PR DESCRIPTION
## Summary
- subscribe to navigation changes in the documentation layout so page transitions reset pending scroll state
- trigger a JavaScript helper after renders to scroll the docs container to the top and add the helper to the shared module

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d027509034832abaa43e7ef502ea3d