### PR TITLE
Add survey Playwright test and parallel fixture initialization

### DIFF
--- a/JwtIdentity.PlaywrightTests/AssemblyInfo.cs
+++ b/JwtIdentity.PlaywrightTests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.Fixtures)]

--- a/JwtIdentity.PlaywrightTests/Helpers/PlaywrightHelper.cs
+++ b/JwtIdentity.PlaywrightTests/Helpers/PlaywrightHelper.cs
@@ -1,62 +1,129 @@
 using JwtIdentity.Common.ViewModels;
 using Microsoft.Playwright;
-using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
 using System.Net.Http.Json;
 
 namespace JwtIdentity.PlaywrightTests.Helpers
 {
-    public abstract class PlaywrightHelper : PageTest
+    public abstract class PlaywrightHelper
     {
         private static readonly HttpClient HttpClient = CreateHttpClient();
         private string _originalHeadedValue;
+        private IPlaywright _playwright;
+        private IBrowser _browser;
+        private string _currentBrowserName = "chromium";
+
+        protected IBrowserContext Context { get; private set; }
+        protected IPage Page { get; private set; }
+
+        protected virtual bool AutoLogin => false;
+        protected virtual string AutoLoginUsername => "playwrightuser@example.com";
 
         [OneTimeSetUp]
-        public void ConfigurePlaywrightExecutionMode()
+        public async Task GlobalSetUpAsync()
         {
-            _originalHeadedValue = Environment.GetEnvironmentVariable("HEADED");
+            ConfigurePlaywrightExecutionMode();
 
             var settings = PlaywrightTestConfiguration.Settings;
-            var headedValue = settings.Headless ? "0" : "1";
-            Environment.SetEnvironmentVariable("HEADED", headedValue);
 
-            TestContext.Progress.WriteLine($"Playwright headless mode: {settings.Headless}");
+            _playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+
+            var browserType = _playwright.Chromium;
+            _currentBrowserName = browserType.Name;
+
+            var launchOptions = new BrowserTypeLaunchOptions
+            {
+                Headless = settings.Headless
+            };
+
+            _browser = await browserType.LaunchAsync(launchOptions);
+            Context = await _browser.NewContextAsync(ContextOptions());
+            Page = await Context.NewPageAsync();
+
+            if (AutoLogin)
+            {
+                await LoginAsync(AutoLoginUsername);
+                await EnsureAuthenticatedAsync();
+            }
+
+            await OnAfterSetupAsync();
         }
 
+        protected virtual Task OnAfterSetupAsync() => Task.CompletedTask;
+
         [OneTimeTearDown]
-        public void RestorePlaywrightExecutionMode()
+        public async Task GlobalTearDownAsync()
         {
-            Environment.SetEnvironmentVariable("HEADED", _originalHeadedValue);
+            try
+            {
+                if (Page is not null)
+                {
+                    await Page.CloseAsync();
+                }
+
+                if (Context is not null)
+                {
+                    await Context.CloseAsync();
+                }
+
+                if (_browser is not null)
+                {
+                    await _browser.CloseAsync();
+                }
+
+                _playwright?.Dispose();
+            }
+            finally
+            {
+                RestorePlaywrightExecutionMode();
+            }
+        }
+
+        protected virtual BrowserNewContextOptions ContextOptions()
+        {
+            return new BrowserNewContextOptions
+            {
+                BaseURL = BaseUrl,
+                IgnoreHTTPSErrors = true
+            };
         }
 
         protected virtual string BaseUrl => Environment.GetEnvironmentVariable("PLAYWRIGHT_BASE_URL") ?? "https://localhost:5001";
         protected virtual string ApiEndpoint => $"{BaseUrl.TrimEnd('/')}/api/playwrightlog";
         protected virtual string PlaywrightPassword => Environment.GetEnvironmentVariable("PLAYWRIGHT_PASSWORD") ?? "UserPassword123";
 
-        protected string CurrentBrowserName => BrowserType?.Name ?? "chromium";
+        protected string CurrentBrowserName => _currentBrowserName;
 
-        public override BrowserNewContextOptions ContextOptions()
+        protected async Task LoginAsync(string username, string password = null, IPage page = null)
         {
-            var options = base.ContextOptions();
-            options.BaseURL = BaseUrl;
-            options.IgnoreHTTPSErrors = true;
-            return options;
-        }
-
-        protected async Task LoginAsync(string username, string password = null)
-        {
+            var targetPage = page ?? Page ?? throw new InvalidOperationException("Playwright page has not been initialized.");
             password ??= PlaywrightPassword;
-            await Page.GotoAsync("/login");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-            await Page.FillAsync("#username", username);
-            await Page.FillAsync("#password", password);
-            await Page.ClickAsync("button[type='submit']");
+
+            await targetPage.GotoAsync("/login");
+            await targetPage.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await targetPage.FillAsync("#username", username);
+            await targetPage.FillAsync("#password", password);
+            await targetPage.ClickAsync("button[type='submit']");
+            await targetPage.WaitForLoadStateAsync(LoadState.NetworkIdle);
         }
 
-        protected async Task LogoutAsync()
+        protected async Task EnsureAuthenticatedAsync(IPage page = null)
         {
-            await Page.GotoAsync("/logout");
-            await Page.WaitForURLAsync("**/login");
+            var targetPage = page ?? Page ?? throw new InvalidOperationException("Playwright page has not been initialized.");
+
+            var logoutLink = targetPage
+                .GetByRole(AriaRole.Toolbar)
+                .GetByRole(AriaRole.Link, new() { Name = "Logout" });
+
+            await Microsoft.Playwright.Assertions.Expect(logoutLink).ToBeVisibleAsync();
+        }
+
+        protected async Task LogoutAsync(IPage page = null)
+        {
+            var targetPage = page ?? Page ?? throw new InvalidOperationException("Playwright page has not been initialized.");
+
+            await targetPage.GotoAsync("/logout");
+            await targetPage.WaitForURLAsync("**/login");
         }
 
         protected async Task ExecuteWithLoggingAsync(string testName, string targetSelector, Func<Task> testBody)
@@ -86,6 +153,22 @@ namespace JwtIdentity.PlaywrightTests.Helpers
 
                 throw;
             }
+        }
+
+        private void ConfigurePlaywrightExecutionMode()
+        {
+            _originalHeadedValue = Environment.GetEnvironmentVariable("HEADED");
+
+            var settings = PlaywrightTestConfiguration.Settings;
+            var headedValue = settings.Headless ? "0" : "1";
+            Environment.SetEnvironmentVariable("HEADED", headedValue);
+
+            TestContext.Progress.WriteLine($"Playwright headless mode: {settings.Headless}");
+        }
+
+        private void RestorePlaywrightExecutionMode()
+        {
+            Environment.SetEnvironmentVariable("HEADED", _originalHeadedValue);
         }
 
         private async Task LogAsync(PlaywrightLogViewModel log)

--- a/JwtIdentity.PlaywrightTests/Tests/SurveyTests.cs
+++ b/JwtIdentity.PlaywrightTests/Tests/SurveyTests.cs
@@ -1,0 +1,56 @@
+using JwtIdentity.PlaywrightTests.Helpers;
+using Microsoft.Playwright;
+using NUnit.Framework;
+
+namespace JwtIdentity.PlaywrightTests.Tests
+{
+    [TestFixture]
+    public class SurveyTests : PlaywrightHelper
+    {
+        protected override bool AutoLogin => true;
+
+        [Test]
+        public async Task CreateSurveyUsingAI_SurveyCreated()
+        {
+            const string testName = nameof(CreateSurveyUsingAI_SurveyCreated);
+            const string targetSelectorDescription = "Survey creation success snackbar";
+
+            await ExecuteWithLoggingAsync(testName, targetSelectorDescription, async () =>
+            {
+                await Page.GotoAsync("/");
+                await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+                await OpenCreateSurveyAsync();
+
+                var createSurveyHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Create Survey" });
+                await Microsoft.Playwright.Assertions.Expect(createSurveyHeading).ToBeVisibleAsync();
+
+                await Page.FillAsync("#Title", "Customer Satisfaction Survey");
+                await Page.FillAsync("#Description", "Please take our customer satisfaction survey so that we can learn how we did while repairing your refrigerator.");
+                await Page.FillAsync("#AiInstructions", "Create 10 questions. The last question should be a free text question so the user can provide any additional feedback.");
+
+                var createButton = Page.GetByRole(AriaRole.Button, new() { Name = "Create" });
+                await Task.WhenAll(
+                    Page.WaitForURLAsync("**/survey/edit/**"),
+                    createButton.ClickAsync());
+
+                var editSurveyHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Edit Survey" });
+                await Microsoft.Playwright.Assertions.Expect(editSurveyHeading).ToBeVisibleAsync();
+
+                var successToast = Page.Locator(".mud-snackbar").Filter(new() { HasTextString = "Survey Created" });
+                await Microsoft.Playwright.Assertions.Expect(successToast).ToBeVisibleAsync();
+            });
+        }
+
+        private async Task OpenCreateSurveyAsync()
+        {
+            var surveysMenu = Page.GetByRole(AriaRole.Button, new() { Name = "Surveys" });
+            await surveysMenu.ClickAsync();
+
+            var createSurveyMenuItem = Page.GetByRole(AriaRole.Link, new() { Name = "Create Survey" });
+            await Task.WhenAll(
+                Page.WaitForURLAsync("**/survey/create"),
+                createSurveyMenuItem.ClickAsync());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the Playwright test helper to manage its own browser lifecycle, keep one page per fixture, and support optional auto-login
- enable fixture-level parallel execution for the Playwright suite
- add a survey creation end-to-end test that drives the AI-assisted flow and verifies navigation to the edit page and success toast

## Testing
- dotnet test *(fails: Microsoft.Build.Exceptions.InternalLoggerException because required Playwright browser dependencies are missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d04419f394832a803d9d55f09c724a