### PR TITLE
Fix surveys menu locator for Playwright test

### DIFF
--- a/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
+++ b/JwtIdentity.Client/Pages/Navigation/MyNavMenu.razor
@@ -37,7 +37,7 @@
         }
         @if (IsAuthenticated && CanCreateSurvey)
         {
-            <MudMenu Label="Surveys" Variant="Variant.Text" EndIcon="@Icons.Material.Filled.KeyboardArrowDown" Color="Color.Inherit">
+            <MudMenu Id="nav-surveys-menu" Label="Surveys" Variant="Variant.Text" EndIcon="@Icons.Material.Filled.KeyboardArrowDown" Color="Color.Inherit">
                 <MudMenuItem Href="/survey/create">Create Survey</MudMenuItem>
                 <MudMenuItem Href="/mysurveys/surveysicreated">Surveys I've Created</MudMenuItem>
                 <MudMenuItem Href="/survey/surveysianswered">Surveys I've Answered</MudMenuItem>

--- a/JwtIdentity.PlaywrightTests/Tests/SurveyTests.cs
+++ b/JwtIdentity.PlaywrightTests/Tests/SurveyTests.cs
@@ -44,7 +44,7 @@ namespace JwtIdentity.PlaywrightTests.Tests
 
         private async Task OpenCreateSurveyAsync()
         {
-            var surveysMenu = Page.GetByRole(AriaRole.Button, new() { Name = "Surveys" });
+            var surveysMenu = Page.Locator("#nav-surveys-menu button");
             await surveysMenu.ClickAsync();
 
             var createSurveyMenuItem = Page.GetByRole(AriaRole.Link, new() { Name = "Create Survey" });


### PR DESCRIPTION
## Summary
- add an id to the surveys navigation menu button to provide a unique locator
- update the Playwright survey creation test to use the id-based locator when opening the menu

## Testing
- dotnet test JwtIdentity.PlaywrightTests *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d04b557ac8832a974ff1e9008f4261