### PR TITLE
Wait for logout navigation before asserting login link

### DIFF
--- a/JwtIdentity.PlaywrightTests/Tests/AuthTests.cs
+++ b/JwtIdentity.PlaywrightTests/Tests/AuthTests.cs
@@ -21,7 +21,9 @@ namespace JwtIdentity.PlaywrightTests.Tests
                     .GetByRole(AriaRole.Link, new() { Name = "Logout" });
                 await Microsoft.Playwright.Assertions.Expect(logoutLink).ToBeVisibleAsync();
 
-                await logoutLink.ClickAsync();
+                await Task.WhenAll(
+                    Page.WaitForURLAsync("**/login**"),
+                    logoutLink.ClickAsync());
 
                 var loginLink = Page
                     .GetByRole(AriaRole.Toolbar)


### PR DESCRIPTION
## Summary
- wait for the login page navigation to finish after clicking the logout link in the Playwright login test
- ensure the login toolbar link is asserted only after the logout redirect completes

## Testing
- `dotnet test JwtIdentity.PlaywrightTests` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d052dc1234832a99855ff8aa268bd9