### PR TITLE
Fix local function name conflict in OpenAiService

### DIFF
--- a/JwtIdentity/Services/OpenAiService.cs
+++ b/JwtIdentity/Services/OpenAiService.cs
@@ -158,7 +158,7 @@ namespace JwtIdentity.Services
                             return true;
                         }
 
-                        if (value.TryGetValue<string>(out var stringValue) && TryConvertQuestionType(stringValue, out discriminator))
+                        if (value.TryGetValue<string>(out var stringValue) && TryConvertQuestionTypeFromString(stringValue, out discriminator))
                         {
                             return true;
                         }
@@ -172,7 +172,7 @@ namespace JwtIdentity.Services
                     return false;
                 }
 
-                bool TryConvertQuestionType(string? raw, out int discriminator)
+                bool TryConvertQuestionTypeFromString(string? raw, out int discriminator)
                 {
                     discriminator = default;
 


### PR DESCRIPTION
## Summary
- rename the string conversion helper in `OpenAiService` to avoid a duplicate local function name conflict

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d59a9e96c8832a8f5ab2a9f97deb38