### PR TITLE
Fix polymorphic metadata collisions for survey questions

### DIFF
--- a/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace JwtIdentity.Common.ViewModels
 {
-    [JsonPolymorphic(TypeDiscriminatorPropertyName = "answerType", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]
+    [JsonPolymorphic(TypeDiscriminatorPropertyName = "$answerType", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]
     [JsonDerivedType(typeof(TextAnswerViewModel), (int)AnswerType.Text)]
     [JsonDerivedType(typeof(TrueFalseAnswerViewModel), (int)AnswerType.TrueFalse)]
     [JsonDerivedType(typeof(SingleChoiceAnswerViewModel), (int)AnswerType.SingleChoice)]

--- a/JwtIdentity.Common/ViewModels/QuestionViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/QuestionViewModel.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace JwtIdentity.Common.ViewModels
 {
-    [JsonPolymorphic(TypeDiscriminatorPropertyName = "questionType", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]
+    [JsonPolymorphic(TypeDiscriminatorPropertyName = "$questionType", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]
     [JsonDerivedType(typeof(TextQuestionViewModel), (int)QuestionType.Text)]
     [JsonDerivedType(typeof(TrueFalseQuestionViewModel), (int)QuestionType.TrueFalse)]
     [JsonDerivedType(typeof(MultipleChoiceQuestionViewModel), (int)QuestionType.MultipleChoice)]


### PR DESCRIPTION
## Summary
- change the polymorphic metadata property names for question and answer view models to avoid collisions with the regular payload properties

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5acc20584832abbd613992605a372