### PR TITLE
Validate question before accepting answers

### DIFF
--- a/JwtIdentity/Controllers/AnswerController.cs
+++ b/JwtIdentity/Controllers/AnswerController.cs
@@ -221,6 +221,18 @@ namespace JwtIdentity.Controllers
                     return BadRequest("Bad Request: Answer data is required");
                 }
 
+                if (answerViewModel.QuestionId <= 0)
+                {
+                    _logger.LogWarning("Invalid question ID {QuestionId} provided while saving answer", answerViewModel.QuestionId);
+                    return BadRequest("A valid question identifier is required");
+                }
+
+                if (!await _context.Questions.AsNoTracking().AnyAsync(q => q.Id == answerViewModel.QuestionId))
+                {
+                    _logger.LogWarning("Question ID {QuestionId} not found while saving answer", answerViewModel.QuestionId);
+                    return BadRequest("Question does not exist");
+                }
+
                 _logger.LogDebug("Mapping answer view model to domain model. Answer type: {AnswerType}", answerViewModel.AnswerType);
                 var answer = _mapper.Map<Answer>(answerViewModel);
 


### PR DESCRIPTION
## Summary
- add validation to ensure posted answers reference a valid question id
- log and return bad requests when the question identifier is missing or unknown

## Testing
- MSBUILDTERMINALLOGGER=off ~/.dotnet/dotnet test *(fails: Playwright browsers are not installed and pwsh is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b05c6fb8832a8bd5ee63622854d1