### PR TITLE
Ensure initialized answers carry their question id

### DIFF
--- a/JwtIdentity.Common/Helpers/QuestionTypeDefinition.cs
+++ b/JwtIdentity.Common/Helpers/QuestionTypeDefinition.cs
@@ -85,6 +85,11 @@ namespace JwtIdentity.Common.Helpers
                 question.Answers.Add(answer);
             }
 
+            // Always ensure the answer is associated with the current question.
+            // Without this, newly initialized answers may be posted with a QuestionId of 0,
+            // which the API rightfully rejects as invalid.
+            answer.QuestionId = question.Id;
+
             _answerInitializer(question, answer);
 
             return answer;


### PR DESCRIPTION
## Summary
- set the question identifier on newly initialized answers so client submissions carry a valid QuestionId

## Testing
- dotnet test JwtIdentity.Tests/JwtIdentity.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d5b40b62c8832aa74f9b471fc570c0