### PR TITLE
Fix answer polymorphic deserialization error

### DIFF
--- a/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace JwtIdentity.Common.ViewModels
 {
-    [JsonPolymorphic(TypeDiscriminatorPropertyName = "$answerType", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]
+    [JsonPolymorphic(TypeDiscriminatorPropertyName = "answerType", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]
     [JsonDerivedType(typeof(TextAnswerViewModel), (int)AnswerType.Text)]
     [JsonDerivedType(typeof(TrueFalseAnswerViewModel), (int)AnswerType.TrueFalse)]
     [JsonDerivedType(typeof(SingleChoiceAnswerViewModel), (int)AnswerType.SingleChoice)]


### PR DESCRIPTION
## Summary
- align the AnswerViewModel polymorphic discriminator name with the serialized property used by the API response

## Testing
- `dotnet test JwtIdentity.Tests` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b8c33ef0832a8fa8a44b1552183e