### PR TITLE
Adjust answer polymorphic discriminator name

### DIFF
--- a/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace JwtIdentity.Common.ViewModels
 {
-    [JsonPolymorphic(TypeDiscriminatorPropertyName = "answerType", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]
+    [JsonPolymorphic(TypeDiscriminatorPropertyName = "$answerType", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]
     [JsonDerivedType(typeof(TextAnswerViewModel), (int)AnswerType.Text)]
     [JsonDerivedType(typeof(TrueFalseAnswerViewModel), (int)AnswerType.TrueFalse)]
     [JsonDerivedType(typeof(SingleChoiceAnswerViewModel), (int)AnswerType.SingleChoice)]


### PR DESCRIPTION
## Summary
- update the AnswerViewModel discriminator metadata name so it no longer conflicts with the answerType payload property

## Testing
- `dotnet test JwtIdentity.Tests` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bb6d6af0832aabdcf0a0344eab65