### PR TITLE
Fix AnswerViewModel polymorphic serialization

### DIFF
--- a/JwtIdentity.Client/Services/ApiService.cs
+++ b/JwtIdentity.Client/Services/ApiService.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using JwtIdentity.Common.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Http;
 
@@ -37,6 +38,7 @@ namespace JwtIdentity.Client.Services
                 PropertyNameCaseInsensitive = true,
                 ReferenceHandler = ReferenceHandler.IgnoreCycles
             };
+            _options.Converters.Add(new AnswerViewModelJsonConverter());
             _httpClientFactory = httpClientFactory;
             this.navigationManager = navigationManager;
             this.serviceProvider = serviceProvider;

--- a/JwtIdentity.Common/ViewModels/AnswerViewModelJsonConverter.cs
+++ b/JwtIdentity.Common/ViewModels/AnswerViewModelJsonConverter.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace JwtIdentity.Common.ViewModels
+{
+    public class AnswerViewModelJsonConverter : JsonConverter<AnswerViewModel>
+    {
+        public override AnswerViewModel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using var document = JsonDocument.ParseValue(ref reader);
+            var root = document.RootElement;
+
+            if (!TryGetDiscriminator(root, out var discriminator))
+            {
+                throw new JsonException("The JSON payload for AnswerViewModel must specify an answer type discriminator.");
+            }
+
+            var json = root.GetRawText();
+
+            return discriminator switch
+            {
+                AnswerType.Text => JsonSerializer.Deserialize<TextAnswerViewModel>(json, options),
+                AnswerType.TrueFalse => JsonSerializer.Deserialize<TrueFalseAnswerViewModel>(json, options),
+                AnswerType.SingleChoice => JsonSerializer.Deserialize<SingleChoiceAnswerViewModel>(json, options),
+                AnswerType.MultipleChoice => JsonSerializer.Deserialize<MultipleChoiceAnswerViewModel>(json, options),
+                AnswerType.Rating1To10 => JsonSerializer.Deserialize<Rating1To10AnswerViewModel>(json, options),
+                AnswerType.SelectAllThatApply => JsonSerializer.Deserialize<SelectAllThatApplyAnswerViewModel>(json, options),
+                _ => throw new JsonException($"Unsupported AnswerType discriminator value: {discriminator}.")
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, AnswerViewModel value, JsonSerializerOptions options)
+        {
+            var element = JsonSerializer.SerializeToElement(value, value.GetType(), options);
+
+            writer.WriteStartObject();
+            writer.WriteNumber("$answerType", (int)value.AnswerType);
+
+            foreach (var property in element.EnumerateObject())
+            {
+                property.WriteTo(writer);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        private static bool TryGetDiscriminator(JsonElement element, out AnswerType answerType)
+        {
+            if (TryGetAnswerTypeValue(element, "$answerType", out var discriminatorValue) ||
+                TryGetAnswerTypeValue(element, "answerType", out discriminatorValue))
+            {
+                answerType = (AnswerType)discriminatorValue;
+                return true;
+            }
+
+            answerType = default;
+            return false;
+        }
+
+        private static bool TryGetAnswerTypeValue(JsonElement element, string propertyName, out int value)
+        {
+            if (element.TryGetProperty(propertyName, out var typeProperty) && typeProperty.TryGetInt32(out var discriminator))
+            {
+                value = discriminator;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+    }
+}

--- a/JwtIdentity/Program.cs
+++ b/JwtIdentity/Program.cs
@@ -3,6 +3,7 @@ using Hangfire;
 using Hangfire.SqlServer;
 using JwtIdentity.Client.Helpers;
 using JwtIdentity.Client.Services;
+using JwtIdentity.Common.ViewModels;
 using JwtIdentity.Hubs;
 using JwtIdentity.Middleware;
 using JwtIdentity.Search;
@@ -243,6 +244,7 @@ builder.Services.AddControllers(options =>
 }).AddJsonOptions(opts =>
 {
     opts.JsonSerializerOptions.ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles;
+    opts.JsonSerializerOptions.Converters.Add(new AnswerViewModelJsonConverter());
 }).AddOData(options =>
 {
     _ = options.Select().Filter().OrderBy().Count().Expand().SetMaxTop(null);


### PR DESCRIPTION
## Summary
- add a shared AnswerViewModelJsonConverter that reads and writes the answer type discriminator
- register the converter with both the API and client JSON serializer options to preserve derived answer details

## Testing
- `dotnet test JwtIdentity.Tests` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5be5668a4832a8fa505ba318d76a2