### PR TITLE
Fix AnswerViewModel converter metadata conflict

### DIFF
--- a/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
@@ -2,13 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace JwtIdentity.Common.ViewModels
 {
-    [JsonPolymorphic(TypeDiscriminatorPropertyName = "$answerType", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]
-    [JsonDerivedType(typeof(TextAnswerViewModel), (int)AnswerType.Text)]
-    [JsonDerivedType(typeof(TrueFalseAnswerViewModel), (int)AnswerType.TrueFalse)]
-    [JsonDerivedType(typeof(SingleChoiceAnswerViewModel), (int)AnswerType.SingleChoice)]
-    [JsonDerivedType(typeof(MultipleChoiceAnswerViewModel), (int)AnswerType.MultipleChoice)]
-    [JsonDerivedType(typeof(Rating1To10AnswerViewModel), (int)AnswerType.Rating1To10)]
-    [JsonDerivedType(typeof(SelectAllThatApplyAnswerViewModel), (int)AnswerType.SelectAllThatApply)]
+    [JsonConverter(typeof(AnswerViewModelJsonConverter))]
     public abstract class AnswerViewModel : BaseViewModel
     {
         protected AnswerViewModel()


### PR DESCRIPTION
## Summary
- remove the JsonPolymorphic metadata attributes from AnswerViewModel and annotate it with the existing custom converter to prevent metadata write/read attempts that crash the pipeline when serializing survey answers

## Testing
- dotnet test JwtIdentity.Tests


------
https://chatgpt.com/codex/tasks/task_e_68d5c728e884832aa2779cda5bf0181d