### PR TITLE
Enable persistent state for survey hydration

### DIFF
--- a/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
@@ -1110,7 +1110,7 @@ namespace JwtIdentity.Client.Pages.Survey
             _initialized = true;
 
             await HandleLoggingInUser();
-            if (Survey == null || Survey.Id == 0)
+            if (Survey?.Id == 0)
             {
                 await LoadData();
             }

--- a/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
@@ -12,7 +12,8 @@ namespace JwtIdentity.Client.Pages.Survey
         [Parameter]
         public Guid SurveyId { get; set; }
 
-        protected SurveyViewModel Survey { get; set; }
+        [PersistentState]
+        public SurveyViewModel Survey { get; set; }
 
         protected List<AnswerViewModel> Answers { get; set; } = new List<AnswerViewModel>();
 
@@ -1115,7 +1116,15 @@ namespace JwtIdentity.Client.Pages.Survey
             _initialized = true;
 
             await HandleLoggingInUser();
-            await LoadData();
+            if (Survey == null || Survey.Id == 0)
+            {
+                await LoadData();
+            }
+            else
+            {
+                InitializeBranchingQuestions();
+            }
+
             Loading = false;
         }
     }

--- a/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
@@ -15,12 +15,6 @@ namespace JwtIdentity.Client.Pages.Survey
         [PersistentState]
         public SurveyViewModel Survey { get; set; }
 
-        protected List<AnswerViewModel> Answers { get; set; } = new List<AnswerViewModel>();
-
-        protected int SelectedOptionId { get; set; }
-
-        protected string Url => $"{NavigationManager.BaseUri}survey/{Survey?.Guid ?? ""}";
-
         protected bool isCaptchaVerified { get; set; } = false;
 
         protected bool Preview { get; set; }

--- a/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/AnswerViewModel.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace JwtIdentity.Common.ViewModels
 {
+    [JsonConverter(typeof(AnswerViewModelConverter))]
     public abstract class AnswerViewModel : BaseViewModel
     {
         public int Id { get; set; }

--- a/JwtIdentity.Common/ViewModels/QuestionViewModel.cs
+++ b/JwtIdentity.Common/ViewModels/QuestionViewModel.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace JwtIdentity.Common.ViewModels
 {
+    [JsonConverter(typeof(QuestionViewModelConverter))]
     public abstract class QuestionViewModel : BaseViewModel
     {
         public int Id { get; set; }


### PR DESCRIPTION
## Summary
- mark the survey view model with the new PersistentState attribute to preserve prerendered data
- reuse existing survey data during initialization to avoid unnecessary reloads while keeping branching setup intact
- add JsonConverter annotations to polymorphic question and answer view models so persistent state serialization works

## Testing
- dotnet build JwtIdentity.sln *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921d432d52c832ab045d6207e9ad373)