### PR TITLE
Implement persistent component state for survey page

### DIFF
--- a/JwtIdentity.Client/Pages/BlazorBase.cs
+++ b/JwtIdentity.Client/Pages/BlazorBase.cs
@@ -42,6 +42,9 @@ namespace JwtIdentity.Client.Pages
 
         [Inject]
         internal ILogger<BlazorBase> Logger { get; set; }
+
+        [Inject]
+        internal PersistentComponentState PersistentComponentState { get; set; }
 #pragma warning restore CS8618
 
         private HttpClient _client;

--- a/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
+++ b/JwtIdentity.Client/Pages/Survey/Survey.razor.cs
@@ -6,13 +6,15 @@ namespace JwtIdentity.Client.Pages.Survey
     public class SurveyModel : BlazorBase, IAsyncDisposable
     {
         private int _previousDemoStep = -1;
-        
+
         private bool _initialized;
+
+        private PersistingComponentStateSubscription _persistingStateSubscription;
 
         [Parameter]
         public Guid SurveyId { get; set; }
 
-        [PersistentState]
+        [PersistentState("Survey")]
         public SurveyViewModel Survey { get; set; }
 
         protected bool isCaptchaVerified { get; set; } = false;
@@ -101,6 +103,22 @@ namespace JwtIdentity.Client.Pages.Survey
         private HashSet<int> _groupsToVisit = new();
         private HashSet<int> _visitedGroups = new();
         private int _currentGroupId = 0;
+
+        protected override void OnInitialized()
+        {
+            _persistingStateSubscription = PersistentComponentState.RegisterOnPersisting(PersistSurveyState);
+
+            if (PersistentComponentState.TryTakeFromJson<SurveyViewModel>("Survey", out var restoredSurvey))
+            {
+                Survey = restoredSurvey;
+            }
+        }
+
+        private Task PersistSurveyState()
+        {
+            PersistentComponentState.PersistAsJson("Survey", Survey);
+            return Task.CompletedTask;
+        }
 
         // Calculate total question count based on groups to visit
         protected int CalculateTotalQuestions()
@@ -426,6 +444,8 @@ namespace JwtIdentity.Client.Pages.Survey
                 {
                     // Dispose managed resources
                     objRef?.Dispose();
+
+                    _persistingStateSubscription?.Dispose();
 
                     var authState = await AuthStateProvider.GetAuthenticationStateAsync();
                     ClaimsPrincipal user = authState.User;

--- a/JwtIdentity.Client/Program.cs
+++ b/JwtIdentity.Client/Program.cs
@@ -15,6 +15,7 @@ builder.Configuration
     .AddJsonFile($"appsettings.{builder.HostEnvironment.Environment}.json", optional: true, reloadOnChange: true);
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped<PersistentComponentState>();
 
 builder.Services.AddScoped<IApiService, ApiService>();
 builder.Services.AddScoped<SurveyHubClient>();


### PR DESCRIPTION
## Summary
- inject `PersistentComponentState` into the shared Blazor base component for reuse
- register the persistent component state service in the WebAssembly client startup
- configure the survey page to name and persist its survey data and clean up the subscription

## Testing
- dotnet build JwtIdentity.sln *(fails: `dotnet` is not available in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ef31e6f4832a9d4ac6e5b2376e5e)